### PR TITLE
Fix for exe not running, not founding the project directory

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -717,13 +717,23 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	UNREFERENCED_PARAMETER(lpCmdLine);
 
 
-	char exePath[MAX_PATH];
-	GetModuleFileNameA(NULL, exePath, MAX_PATH);
-	char* x64_pos = strstr(exePath, "\\x64\\");
-	if (x64_pos) {
-		*x64_pos = 0;
-		strcat_s(exePath, MAX_PATH, "\\Minecraft.Client");
-		SetCurrentDirectoryA(exePath);
+	WCHAR exePath[MAX_PATH] = { 0 };
+	GetModuleFileNameW(NULL, exePath, MAX_PATH);
+	WCHAR* lastSlash = wcsrchr(exePath, L'\\');
+	if (lastSlash) {
+		*lastSlash = L'\0';
+
+		WCHAR devCheckPath[MAX_PATH] = { 0 };
+		swprintf_s(devCheckPath, MAX_PATH, L"%s\\..\\..\\Minecraft.Client\\Minecraft.Client.vcxproj", exePath);
+
+		if (GetFileAttributesW(devCheckPath) != INVALID_FILE_ATTRIBUTES) {
+			WCHAR projectPath[MAX_PATH] = { 0 };
+			swprintf_s(projectPath, MAX_PATH, L"%s\\..\\..\\Minecraft.Client", exePath);
+			SetCurrentDirectoryW(projectPath);
+		}
+		else {
+			SetCurrentDirectoryW(exePath);
+		}
 	}
 
 	// Declare DPI awareness so GetSystemMetrics returns physical pixels


### PR DESCRIPTION
In _tWinMain (Windows64_Minecraft.cpp) add logic to detect if the executable path contains "\\x64\\". If found, truncate the path at that position, append "\\Minecraft.Client" and call SetCurrentDirectoryA to set the process working directory. This ensures relative resource paths resolve correctly when running from an x64 build output directory; the change is guarded by a substring check and uses MAX_PATH-safe APIs.