### PR TITLE
Crafting menu LB RB KBM fix

### DIFF
--- a/Minecraft.Client/Common/UI/UIController.cpp
+++ b/Minecraft.Client/Common/UI/UIController.cpp
@@ -935,6 +935,8 @@ void UIController::handleKeyPress(unsigned int iPad, unsigned int key)
 			case ACTION_MENU_CANCEL:    kbDown = KMInput.IsKeyDown(VK_ESCAPE); kbPressed = KMInput.IsKeyPressed(VK_ESCAPE); kbReleased = KMInput.IsKeyReleased(VK_ESCAPE); break;
 			case ACTION_MENU_B:         kbDown = KMInput.IsKeyDown(VK_ESCAPE); kbPressed = KMInput.IsKeyPressed(VK_ESCAPE); kbReleased = KMInput.IsKeyReleased(VK_ESCAPE); break;
 			case ACTION_MENU_PAUSEMENU: kbDown = KMInput.IsKeyDown(VK_ESCAPE); kbPressed = KMInput.IsKeyPressed(VK_ESCAPE); kbReleased = KMInput.IsKeyReleased(VK_ESCAPE); break;
+			case ACTION_MENU_LEFT_SCROLL: kbDown = KMInput.IsKeyDown('Q'); kbPressed = KMInput.IsKeyPressed('Q'); kbReleased = KMInput.IsKeyReleased('Q'); break;
+			case ACTION_MENU_RIGHT_SCROLL: kbDown = KMInput.IsKeyDown('E'); kbPressed = KMInput.IsKeyPressed('E'); kbReleased = KMInput.IsKeyReleased('E'); break;
 		}
 		pressed = pressed || kbPressed;
 		released = released || kbReleased;


### PR DESCRIPTION
# Pull Request Template

## Description
Allows you to use the crafting menu on KBM (switching categories). I made these to Q and E, and this doesn't appear to interfere with drop or inventory.

## Changes

### Previous Behavior
There was no way to switch crafting menu categories with just the keyboard/mouse.

### Root Cause
There simply was no keybind to RB or LB.

### New Behavior
Now in the crafting menu you can click Q and E to cycle between categories. These keys seems the most natural.

### Fix Implementation
All I did was add two more cases in the switch statement in UIController.cpp next to all the other KB patches.
