### PR TITLE
Increase GDRAW_D3D11_RESOURCE_rendertarget limit from 32 MB to 64 MB (or more) …

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_UIController.cpp
+++ b/Minecraft.Client/Windows64/Windows64_UIController.cpp
@@ -50,7 +50,7 @@ void ConsoleUIController::init(ID3D11Device *dev, ID3D11DeviceContext *ctx, ID3D
 	really big so if you substitute a different file it should work. */
 	gdraw_D3D11_SetResourceLimits(GDRAW_D3D11_RESOURCE_vertexbuffer, 5000,  16 * 1024 * 1024);
 	gdraw_D3D11_SetResourceLimits(GDRAW_D3D11_RESOURCE_texture     , 5000, 128 * 1024 * 1024);
-	gdraw_D3D11_SetResourceLimits(GDRAW_D3D11_RESOURCE_rendertarget,   10,  32 * 1024 * 1024);
+	gdraw_D3D11_SetResourceLimits(GDRAW_D3D11_RESOURCE_rendertarget,   10,  64 * 1024 * 1024);
 
 	/* GDraw is all set, so we'll point Iggy at it. */
 	IggySetGDraw(gdraw_funcs);


### PR DESCRIPTION
# Pull Request

## Description
When running the game at high resolutions, this warning keeps showing up during debugging:

> *Iggy Warning: GDraw rendertarget allocation failed: hit size limit of 33554432 bytes*

Because the 32 MB limit for *GDRAW_D3D11_RESOURCE_rendertarget* is low at high resolutions.

## Changes

In `Minecraft.Client\Windows64\Windows64_UIController.cpp`, you can change the 32 from this line:
```
gdraw_D3D11_SetResourceLimits(GDRAW_D3D11_RESOURCE_rendertarget, 10, 32 * 1024 * 1024);
```
To 64:
```
gdraw_D3D11_SetResourceLimits(GDRAW_D3D11_RESOURCE_rendertarget, 10, 64 * 1024 * 1024);
```