### PR TITLE
fix: update Discord invite link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MinecraftConsoles
 
-[![Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/5CSzhc9t)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/NKEfuuJ2Dc)
 
 ![img.png](.github/IMG_8725.png)
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes invalid discord link button in README.md

## Changes
Change discord invite link

### Previous Behavior
Discord invalid server invite link page

### Root Cause
Invalid discord invite link

### New Behavior
Server invite works properly

### Fix Implementation
Generated a new discord server link and removed old invalid link

## Related Issues
- Fixes #86 
- Related to #86 
