### PR TITLE
Fix slow sideways movement whilst fly-sprinting

### DIFF
--- a/Minecraft.Client/LocalPlayer.cpp
+++ b/Minecraft.Client/LocalPlayer.cpp
@@ -462,9 +462,14 @@ void LocalPlayer::aiStep()
 			if( isSprinting() )
 			{
 				// Accelrate up to full speed if we are sprinting, moving in the direction of the view vector
-				flyX = (float)viewVector->x * input->ya;
+				float yawRad = yRot * (PI / 180.0f);
+				
+				flyX = -sinf(yawRad) * input->ya + cosf(yawRad) * input->xa;
 				flyY = (float)viewVector->y * input->ya;
-				flyZ = (float)viewVector->z * input->ya;
+				flyZ = cosf(yawRad) * input->ya + sinf(yawRad) * input->xa;
+				
+				float h = sqrtf(flyX * flyX + flyZ * flyZ);
+				if (h > 1.0f) { flyX /= h; flyZ /= h; }
 
 				float scale = ((float)(SPRINT_DURATION - sprintTime))/10.0f;
 				scale = scale * scale;


### PR DESCRIPTION
In creative mode, when flying whilst sprinting, sideways movement was very slow. Fixed so that now, sideways speed is normal.
Tbh the whole flight movement code is janky and needs to be revised in the future