### PR TITLE
Move to a postbuild.ps1 script and set the working dir at runtime as output dir

### DIFF
--- a/Minecraft.Client/Minecraft.Client.vcxproj
+++ b/Minecraft.Client/Minecraft.Client.vcxproj
@@ -1302,14 +1302,8 @@ if not exist "$(TargetDir)\savedata" mkdir "$(TargetDir)\savedata"</Command>
       <ForceFileOutput>MultiplyDefinedSymbolOnly</ForceFileOutput>
     </Link>
     <PostBuildEvent>
-      <Message>Copying sound assets to output directory</Message>
-      <Command>xcopy /q /y /i /s /e "$(ProjectDir)Durango\Sound" "$(OutDir)Durango\Sound"
-xcopy /q /y /i /s /e "$(ProjectDir)music" "$(OutDir)music"
-xcopy /q /y /i /s /e "$(ProjectDir)Windows64\GameHDD" "$(OutDir)Windows64\GameHDD"
-xcopy /q /y /i /s /e "$(ProjectDir)Common\Media" "$(OutDir)Common\Media"
-xcopy /q /y /i /s /e "$(ProjectDir)Common\res" "$(OutDir)Common\res"
-xcopy /q /y /i /s /e "$(ProjectDir)Common\Trial" "$(OutDir)Common\Trial"
-xcopy /q /y /i /s /e "$(ProjectDir)Common\Tutorial" "$(OutDir)Common\Tutorial"</Command>
+      <Message>Run postbuild script</Message>
+      <Command>powershell -ExecutionPolicy Bypass -File "$(ProjectDir)postbuild.ps1" -OutDir "$(OutDir)/" -ProjectDir "$(ProjectDir)/"</Command>
     </PostBuildEvent>
     <ImageXex>
       <ConfigurationFile>$(ProjectDir)xbox\xex-dev.xml</ConfigurationFile>
@@ -1440,25 +1434,8 @@ xcopy /q /y /i /s /e $(ProjectDir)Durango\CU  $(LayoutDir)Image\Loose\CU</Comman
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
     <PostBuildEvent>
-      <Message>Copying game assets to output directory</Message>
-      <Command>mkdir "$(OutDir)music" 2&gt;nul
-mkdir "$(OutDir)Windows64\GameHDD" 2&gt;nul
-mkdir "$(OutDir)Common\Media" 2&gt;nul
-mkdir "$(OutDir)Common\res" 2&gt;nul
-mkdir "$(OutDir)Common\Trial" 2&gt;nul
-mkdir "$(OutDir)Common\Tutorial" 2&gt;nul
-mkdir "$(OutDir)Windows64Media" 2&gt;nul
-
-xcopy /q /y /i /s /e "$(ProjectDir)music" "$(OutDir)music" || exit /b 0
-xcopy /q /y /i /s /e "$(ProjectDir)Windows64\GameHDD" "$(OutDir)Windows64\GameHDD" || exit /b 0
-xcopy /q /y /i /s /e "$(ProjectDir)Common\Media" "$(OutDir)Common\Media" || exit /b 0
-xcopy /q /y /i /s /e "$(ProjectDir)Common\res" "$(OutDir)Common\res" || exit /b 0
-xcopy /q /y /i /s /e "$(ProjectDir)Common\Trial" "$(OutDir)Common\Trial" || exit /b 0
-xcopy /q /y /i /s /e "$(ProjectDir)Common\Tutorial" "$(OutDir)Common\Tutorial" || exit /b 0
-xcopy /q /y /i /s /e "$(ProjectDir)DurangoMedia" "$(OutDir)Windows64Media" || exit /b 0
-xcopy /q /y /i /s /e "$(ProjectDir)Windows64Media" "$(OutDir)Windows64Media" || exit /b 0
-
-exit /b 0</Command>
+      <Message>Run postbuild script</Message>
+      <Command>powershell -ExecutionPolicy Bypass -File "$(ProjectDir)postbuild.ps1" -OutDir "$(OutDir)/" -ProjectDir "$(ProjectDir)/"</Command>
     </PostBuildEvent>
     <ImageXex>
       <ConfigurationFile>$(ProjectDir)xbox\xex-dev.xml</ConfigurationFile>

--- a/Minecraft.Client/Minecraft.Client.vcxproj.user
+++ b/Minecraft.Client/Minecraft.Client.vcxproj.user
@@ -3,4 +3,12 @@
   <PropertyGroup>
     <LastConfigDeployed>Debug</LastConfigDeployed>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
 </Project>

--- a/Minecraft.Client/postbuild.ps1
+++ b/Minecraft.Client/postbuild.ps1
@@ -1,0 +1,41 @@
+param(
+    [string]$OutDir,
+    [string]$ProjectDir
+)
+
+Write-Host "Post-build script started. Output Directory: $OutDir, Project Directory: $ProjectDir"
+
+$directories = @(
+    "music",
+    "Windows64\GameHDD",
+    "Common\Media",
+    "Common\res",
+    "Common\Trial",
+    "Common\Tutorial",
+    "Windows64Media"
+)
+
+foreach ($dir in $directories) {
+    New-Item -ItemType Directory -Path (Join-Path $OutDir $dir) -Force | Out-Null
+}
+
+$copies = @(
+    @{ Source = "music";           Dest = "music" },
+    @{ Source = "Windows64\GameHDD"; Dest = "Windows64\GameHDD" },
+    @{ Source = "Common\Media";    Dest = "Common\Media" },
+    @{ Source = "Common\res";      Dest = "Common\res" },
+    @{ Source = "Common\Trial";    Dest = "Common\Trial" },
+    @{ Source = "Common\Tutorial"; Dest = "Common\Tutorial" },
+    @{ Source = "DurangoMedia";    Dest = "Windows64Media" },
+    @{ Source = "Windows64Media";  Dest = "Windows64Media" },
+    @{ Source = "Durango\Sound";  Dest = "Windows64Media\Sound" }
+)
+
+foreach ($copy in $copies) {
+    $src = Join-Path $ProjectDir $copy.Source
+    $dst = Join-Path $OutDir $copy.Dest
+
+    if (Test-Path $src) {
+		xcopy /q /y /i /s /e "$src" "$dst" 2>$null
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
This moves all post-build actions out to a separate script and also sets the working directory at runtime to use the correct set of files in the output folder

## Changes

### Previous Behavior
The post-build commands were set per configuration, this unifies them.
The files loaded at runtime were the ones from the project folder not the output folder.

## Extra
Music should also be fixed as some people were complaining about it.