### PR TITLE
Allow TAB to open host options

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -1220,6 +1220,17 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 			ToggleFullscreen();
 		}
 
+		// TAB opens host options menu. - Vvis :3 
+		if (KMInput.IsKeyPressed(VK_TAB))
+		{
+			if (Minecraft* pMinecraft = Minecraft::GetInstance())
+			{
+				{
+					ui.NavigateToScene(0, eUIScene_InGameHostOptionsMenu);
+				}
+			}
+		}
+
 #if 0
 		// has the game defined profile data been changed (by a profile load)
 		if(app.uiGameDefinedDataChangedBitmask!=0)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This project contains the source code of Minecraft Legacy Console Edition v1.3.0
 - **Attack / Destroy**: `Left Click`
 - **Use / Place**: `Right Click`
 - **Select Item**: `Mouse Wheel` or keys `1` to `9`
+- **Host Options**: `TAB`
 
 ## Build & Run
 


### PR DESCRIPTION
# Pull Request

## Description
This change allows the user to press TAB on their keyboard to open the host options 

## Changes

### Previous Behavior
Player was unable to open host options using keyboard

### Root Cause
There was no button for it.

### New Behavior
There is now a button for it

### Fix Implementation
the TAB button was assigned to open the menu. 

## Related Issues
Unrelated to anything 
