### PR TITLE
Implement item drop functionality with Q key

### DIFF
--- a/Minecraft.Client/Input.cpp
+++ b/Minecraft.Client/Input.cpp
@@ -169,6 +169,45 @@ void Input::tick(LocalPlayer *player)
 	if (iPad == 0 && KMInput.IsKeyDown(VK_SPACE) && pMinecraft->localgameModes[iPad]->isInputAllowed(MINECRAFT_ACTION_JUMP))
 		jumping = true;
 #endif
+	
+#ifdef _WINDOWS64
+    // Keyboard drop (Q)
+    // Press Q to drop one item. Hold Ctrl+Q to drop the whole stack.
+    if (iPad == 0 && KMInput.ConsumeKeyPress('Q') && pMinecraft->localgameModes[iPad]->isInputAllowed(MINECRAFT_ACTION_DROP) && !menuOpen)
+	{
+		// Prevent dropping while actively destroying a block (fix crash)
+		MultiPlayerGameMode *mpgm = nullptr;
+		if (pMinecraft->localgameModes[iPad] != NULL)
+		{
+			mpgm = dynamic_cast<MultiPlayerGameMode *>(pMinecraft->localgameModes[iPad]);
+		}
+		if (mpgm != nullptr && mpgm->IsDestroying())
+		{
+			// ignore drop while destroying
+		}
+		else
+		{
+		if (player != NULL)
+		{
+			// If CTRL is held, drop the entire stack
+			if (KMInput.IsKeyDown(VK_CONTROL))
+			{
+				shared_ptr<ItemInstance> sel = player->inventory->getSelected();
+				if (sel != NULL)
+				{
+					shared_ptr<ItemInstance> toDrop = player->inventory->removeItem(player->inventory->selected, sel->count);
+					if (toDrop != NULL) player->drop(toDrop, false);
+				}
+			}
+			else
+			{
+				// Drop a single item (Player::drop() will remove 1 from selected)
+				player->drop();
+			}
+		}
+		}
+	}
+#endif
 
 #ifndef _CONTENT_PACKAGE
 	if (app.GetFreezePlayers())	jumping = false;


### PR DESCRIPTION
Added functionality to drop items using the Q key, with support for dropping entire stacks when Ctrl is held. Included checks to prevent dropping items while destroying blocks.

# Pull Request

## Description
Adds a reliable keyboard shortcut for dropping items. Pressing Q drops a single item from the currently selected slot; holding Ctrl + Q drops the entire stack. The feature is only active when no UI/menu is open and will not trigger while the player is actively destroying a block.

## Changes

### Previous Behavior

	Pressing Q did not always trigger a drop reliably; input was sometimes missed or incorrectly consumed when menus or XUI scenes were active.
	There was no consistent handling for dropping entire stacks with a modifier key.
	Dropping while destroying blocks could lead to undesirable behavior.

### Root Cause

	Input for Q was not consumed consistently at game tick rate and sometimes conflicted with UI key handling, causing unreliable behavior.
	There was no explicit check for modifier keys or for the player/game state (e.g., block destruction) before performing a drop.
	The code did not guard against drops when menus or XUI scenes were displayed, allowing movement/interaction inconsistencies.

### New Behavior

	Q reliably drops one item from the selected slot (game-tick consumption).
	Ctrl + Q drops the entire selected stack.
	Drops are ignored when any screen or XUI menu is open.
	Drops are ignored while the player is destroying a block.
	Behavior is Windows-specific via the existing KMInput APIs (keeps parity with the rest of the input code).

### Fix Implementation

	Modified Input.cpp:240-278 inside Input::tick(LocalPlayer *player):
	Use KMInput.ConsumeKeyPress('Q') to process the key at game tick rate.
	Introduced menuOpen = (pMinecraft->screen != NULL) || ui.GetMenuDisplayed(iPad) and only allow drop when !menuOpen.
	If the local game mode is MultiPlayerGameMode, check mpgm->IsDestroying() and skip drop while destroying.
	For whole-stack drop: check KMInput.IsKeyDown(VK_CONTROL). If held, remove the entire selected stack from the inventory via player->inventory->removeItem(...) and call player->drop(item, false).
	Otherwise, call player->drop() to drop a single item.

