### PR TITLE
Fixed issue 109 with tab menu

### DIFF
--- a/Minecraft.Client/Common/UI/UILayer.cpp
+++ b/Minecraft.Client/Common/UI/UILayer.cpp
@@ -313,6 +313,10 @@ bool UILayer::NavigateToScene(int iPad, EUIScene scene, void *initData)
 		newScene = new UIScene_InGameInfoMenu(iPad, initData, this);
 		break;
 	case eUIScene_InGameHostOptionsMenu:
+		if (IsSceneInStack(eUIScene_InGameHostOptionsMenu)) {
+			app.DebugPrintf("Skipped eUIScene_InGameHostOptionsMenu, we have already this tab!");
+			return false;
+		}
 		newScene = new UIScene_InGameHostOptionsMenu(iPad, initData, this);
 		break;
 	case eUIScene_InGamePlayerOptionsMenu:


### PR DESCRIPTION
# Pull Request

## Description
Fixed issue #109 

## Changes

### Previous Behavior
You had the chance of keep stacking TAB menus infinitely.

### Root Cause
We didn't have a check in the UI that would allow us to verify whether there was a TAB menu in the stack or not.

### New Behavior
Now when we enter in the switch statement of the TAB key we check first if we have this screen in the stack or not.

### Fix Implementation
Now we use **IsSceneInStack** to verify if we have this menu already placed or not before creating this menu again.

## Related Issues
- Fixes #109 
