### PR TITLE
Add hook for modloader

### DIFF
--- a/Minecraft.Client/Minecraft.cpp
+++ b/Minecraft.Client/Minecraft.cpp
@@ -105,6 +105,11 @@ int QuickSelectBoxWidth[3]=
 };
 #endif
 
+extern "C" __declspec(dllexport) Minecraft* GetGameInstance()
+{
+	return Minecraft::m_instance;
+}
+
 Minecraft::Minecraft(Component *mouseComponent, Canvas *parent, MinecraftApplet *minecraftApplet, int width, int height, bool fullscreen)
 {
 	// 4J - added this block of initialisers

--- a/Minecraft.Client/Minecraft.h
+++ b/Minecraft.Client/Minecraft.h
@@ -60,10 +60,8 @@ public:
 	//    void crash(CrashReport crash);
 	//    public abstract void onCrash(CrashReport crash);
 
-private:
 	static Minecraft *m_instance;
 
-public:
 	MultiPlayerGameMode *gameMode;
 
 private:


### PR DESCRIPTION

## Description
This adds a simple hook for modloading systems, including my own

## Changes

Added hook for potential modloaders
```cpp
extern "C" __declspec(dllexport) Minecraft* GetGameInstance();
```

See https://github.com/DanielLMcGuire/LCE-SDK