### PR TITLE
fixed being able to walk, jump and sneak when the inventory, crafting, anvil or chest screens were open

### DIFF
--- a/Minecraft.Client/Input.cpp
+++ b/Minecraft.Client/Input.cpp
@@ -47,7 +47,7 @@ void Input::tick(LocalPlayer *player)
 
 #ifdef _WINDOWS64
 	// WASD movement (combine with gamepad)
-	if (iPad == 0)
+	if (iPad == 0 && KMInput.IsCaptured())
 	{
 		float kbX = 0.0f, kbY = 0.0f;
 		if (KMInput.IsKeyDown('W')) { kbY += 1.0f; sprintForward += 1.0f; usingKeyboardMovement = true; }
@@ -95,7 +95,7 @@ void Input::tick(LocalPlayer *player)
 
 #ifdef _WINDOWS64
 	// Keyboard hold-to-sneak (overrides gamepad toggle)
-	if (iPad == 0 && KMInput.IsKeyDown(VK_SHIFT) && !player->abilities.flying)
+	if (iPad == 0 && KMInput.IsCaptured() && KMInput.IsKeyDown(VK_SHIFT) && !player->abilities.flying)
 		sneaking = true;
 #endif
 
@@ -166,7 +166,7 @@ void Input::tick(LocalPlayer *player)
 
 #ifdef _WINDOWS64
 	// Keyboard jump (Space)
-	if (iPad == 0 && KMInput.IsKeyDown(VK_SPACE) && pMinecraft->localgameModes[iPad]->isInputAllowed(MINECRAFT_ACTION_JUMP))
+	if (iPad == 0 && KMInput.IsCaptured() && KMInput.IsKeyDown(VK_SPACE) && pMinecraft->localgameModes[iPad]->isInputAllowed(MINECRAFT_ACTION_JUMP))
 		jumping = true;
 #endif
 


### PR DESCRIPTION
# Pull Request

## Description
Introduces input locking when the mouse is not captured, those being when for example the inventory screen is open.

## Changes

### Previous Behavior
The player was able to walk, jump and sneak with the inventory open.

### Root Cause
We were checking for the keys pressed but we were not checking for if the mouse was captured. Which the mouse capture is toggled off when opening inventories/containers.

### New Behavior
The player is now locked from walking, jumping and sneaking with inventories/containers open.

### Fix Implementation
I made it so it checks if the mouse is captured, which the mouse capture is toggled off when opening inventories/containers.

## Related Issues
- Fixes #27
