### PR TITLE
WIP Restore Java Achievements

### DIFF
--- a/Minecraft.Client/AchievementPopup.cpp
+++ b/Minecraft.Client/AchievementPopup.cpp
@@ -88,6 +88,7 @@ void AchievementPopup::render()
         glDepthMask(true);
         glEnable(GL_DEPTH_TEST);
     }
+#endif
     if (ach == NULL || startTime == 0) return;
 
     double time = (System::currentTimeMillis() - startTime) / 3000.0;
@@ -115,7 +116,7 @@ void AchievementPopup::render()
 
     int xx = width - 160;
     int yy = 0 - (int) (yo * 36);
-    int tex = mc->textures->loadTexture(L"/achievement/bg.png");
+    int tex = mc->textures->loadTexture(TN_ACHIEVEMENT_BG);
     glColor4f(1, 1, 1, 1);
     glEnable(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, tex);
@@ -125,7 +126,8 @@ void AchievementPopup::render()
 
     if (isHelper)
 	{
-        mc->font->drawWordWrap(desc, xx + 30, yy + 7, 120, 0xffffffff);
+        //mc->font->drawWordWrap(desc, xx + 30, yy + 7, 120, 0xffffffff);
+        mc->font->drawWordWrap(desc, xx + 20, yy + 7, 120, 0xffffffff, 80);
     }
 	else
 	{
@@ -147,5 +149,4 @@ void AchievementPopup::render()
 
     glDepthMask(true);
     glEnable(GL_DEPTH_TEST);
-#endif
 }

--- a/Minecraft.Client/LocalPlayer.cpp
+++ b/Minecraft.Client/LocalPlayer.cpp
@@ -783,8 +783,9 @@ void LocalPlayer::awardStat(Stat *stat, byteArray param)
 		// so let the award manager figure it out
         //if (!minecraft->stats[m_iPad]->hasTaken(ach))
 		{
-            // 4J-PB - Don't display the java popup
-			//minecraft->achievementPopup->popup(ach);
+#ifdef _WINDOWS64
+			minecraft->achievementPopup->popup(ach);
+#endif // _WINDOWS64
 
 			// 4J Stu - Added this function in the libraries as some achievements don't get awarded to all players
 			// e.g. Splitscreen players cannot get theme/avatar/gamerpic and Trial players cannot get any

--- a/Minecraft.Client/Textures.cpp
+++ b/Minecraft.Client/Textures.cpp
@@ -26,7 +26,7 @@ wchar_t *Textures::preLoaded[TN_COUNT] =
 	L"%blur%misc/pumpkinblur",
 //	L"%blur%/misc/vignette",		// Not currently used
 	L"%clamp%misc/shadow",
-//	L"/achievement/bg",				// Not currently used
+	L"/achievement/bg",				// Not currently used
 	L"art/kz",
 	L"environment/clouds",
 	L"environment/rain",

--- a/Minecraft.Client/Textures.h
+++ b/Minecraft.Client/Textures.h
@@ -19,7 +19,7 @@ typedef enum _TEXTURE_NAME
 	TN__BLUR__MISC_PUMPKINBLUR,
 //	TN__BLUR__MISC_VIGNETTE,		// Not currently used
 	TN__CLAMP__MISC_SHADOW,
-//	TN_ACHIEVEMENT_BG,				// Not currently used
+	TN_ACHIEVEMENT_BG,				// Not currently used
 	TN_ART_KZ,
 	TN_ENVIRONMENT_CLOUDS,
 	TN_ENVIRONMENT_RAIN,


### PR DESCRIPTION
# Pull Request
Note: 
This PR cannot currently be merged because the required localization compilation tools are missing. Previously, 4J used a tool to compile all localized strings from every language into a single file (`languages.loc`) within `MediaWindows64.arc`. Once a fix is found, I will revisit and rework this PR.

## Description
Restores Java Achievements from 4J commented code

<img width="1347" height="693" alt="image" src="https://github.com/user-attachments/assets/24402e3a-e43c-4e84-a9d3-d08207051a4a" />