### PR TITLE
Only handle host options when there is no menu on screen

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -1224,7 +1224,7 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 		}
 
 		// TAB opens host options menu. - Vvis :3
-		if (KMInput.IsKeyPressed(VK_TAB))
+		if (KMInput.IsKeyPressed(VK_TAB) && !ui.GetMenuDisplayed(0))
 		{
 			if (Minecraft* pMinecraft = Minecraft::GetInstance())
 			{


### PR DESCRIPTION
# Pull Request

## Description
Fixes #137 

## Changes

### Previous Behavior
Pressing TAB not in a world crashes the game

### Root Cause
Missing if for this case in 75bf7ee54a2d4bbaded95453ac699c5d2d529628

### New Behavior
Any menu on the screen will prevent the host options menu to be opened

### Fix Implementation
```cpp
!ui.GetMenuDisplayed(0)
```
ensures there is no menu on screen

## Related Issues
- Fixes #137 