### PR TITLE
Change flight activation to be similar to java

### DIFF
--- a/Minecraft.Client/LocalPlayer.cpp
+++ b/Minecraft.Client/LocalPlayer.cpp
@@ -365,7 +365,7 @@ void LocalPlayer::aiStep()
 		{
 			if (jumpTriggerTime == 0)
 			{
-				jumpTriggerTime = 10;			// was 7
+				jumpTriggerTime = 7;			// the 4J team changed it to 10 because of additional requirements to initiate flight
 				twoJumpsRegistered = false;
 			}
 			else
@@ -373,7 +373,7 @@ void LocalPlayer::aiStep()
 				twoJumpsRegistered = true;
 			}
 		}
-		else if( ( !input->jumping ) && ( jumpTriggerTime > 0 ) && twoJumpsRegistered )
+		else if(jumpTriggerTime > 0 && twoJumpsRegistered) //the 4J team checked if the player was NOT jumping after the two jumps, aka had let go of the jump button
 		{
 #ifndef _CONTENT_PACKAGE
 			printf("flying was %s\n", abilities.flying ? "on" : "off");


### PR DESCRIPTION
# Pull Request

## Description
Removes the need to let go of the jump button to activate flight

Lowers the flight activation window from 10 ticks to 7 ticks

## Changes

### Previous Behavior
You had to jump twice and let go of the jump button in the span of 10 ticks to activate flight

### New Behavior
You jump twice in the span of 7 ticks to activate flight

### Fix Implementation
Remove the !input->jumping check to activate flight and lower the jumpTriggerTime from 10 to 7