### PR TITLE
Allow for loading of WAVE Audio files

### DIFF
--- a/Minecraft.Client/Common/Audio/SoundEngine.cpp
+++ b/Minecraft.Client/Common/Audio/SoundEngine.cpp
@@ -1329,10 +1329,10 @@ void SoundEngine::playMusicUpdate()
 			else
 			{
 				const char* extensions[] = { ".wav" }; // only wav works outside of binka files to my knowledge, i've only tested ogg, wav, mp3 and only wav worked out of the bunch
-				int count = sizeof(extensions) / sizeof(extensions[0]);
+				size_t count = sizeof(extensions) / sizeof(extensions[0]);
 				bool found = false;
 
-				for (int i = 0; i < count; i++)
+				for (size_t i = 0; i < count; i++)
 				{
 					int n = sprintf_s(reinterpret_cast<char*>(m_szStreamName), 512, "%s%s%s%s", m_szMusicPath, folder, m_szStreamFileA[m_musicID], extensions[i]);
 					if (n < 0) continue;


### PR DESCRIPTION
# Pull Request

## Description
This PR just implements a simple check for .wav files, loading it if the .binka file is not found, making it easier for audio replacements

Simply just a QOL feature, I like the idea of being able to easily replace audio without having to jump through a hoop or two

## Changes

### Previous Behavior
Previously, the game would only check for .binka files

### New Behavior
The game now checks for both .binka and .wav files via an array, making it potentially easier for other audio formats to be added (Would need their own decoders implemented)

https://github.com/user-attachments/assets/a64bfaf9-26cc-4631-b979-27ad92932934

