### PR TITLE
Fix Windows64 mouse capture and static initialization crashes

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -403,6 +403,15 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		if (LOWORD(wParam) == WA_INACTIVE)
 			KMInput.SetCapture(false);
 		break;
+	case WM_SETFOCUS:
+		{
+			// Re-capture when window receives focus (e.g., after clicking on it)
+			Minecraft *pMinecraft = Minecraft::GetInstance();
+			bool shouldCapture = pMinecraft && app.GetGameStarted() && !ui.GetMenuDisplayed(0) && pMinecraft->screen == NULL;
+			if (shouldCapture)
+				KMInput.SetCapture(true);
+		}
+		break;
 	case WM_KILLFOCUS:
 		KMInput.SetCapture(false);
 		KMInput.ClearAllState();

--- a/Minecraft.World/Packet.cpp
+++ b/Minecraft.World/Packet.cpp
@@ -161,9 +161,9 @@ Packet::Packet() : createTime( System::currentTimeMillis() )
 
 unordered_map<int, packetCreateFn> Packet::idToCreateMap;
 
-unordered_set<int> Packet::clientReceivedPackets = unordered_set<int>();
-unordered_set<int> Packet::serverReceivedPackets = unordered_set<int>();
-unordered_set<int> Packet::sendToAnyClientPackets = unordered_set<int>();
+unordered_set<int> Packet::clientReceivedPackets;
+unordered_set<int> Packet::serverReceivedPackets;
+unordered_set<int> Packet::sendToAnyClientPackets;
 
 // 4J Added
 unordered_map<int, Packet::PacketStatistics *> Packet::outgoingStatistics = unordered_map<int, Packet::PacketStatistics *>();


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes two critical bugs in the Windows64 build: mouse capture not restoring after alt+tab or clicking from another window, and heap corruption crashes caused by static initialization order issues in Packet.cpp

## Changes
Fix 1: Mouse Capture After Window Focus Loss

### Previous Behavior
When alt+tabbing out of the game or clicking on another window, the mouse capture was released. Upon returning to the game window (either by alt+tab or clicking on it), the mouse was not re-captured, requiring the user to press ESC to restore proper mouse control

### Root Cause
The WM_ACTIVATE handler only handled WA_INACTIVE to release capture, but there was no corresponding handler to re capture the mouse when the window regained focus. The existing capture logic in the main loop only triggered when GetFocus() == g_hWnd, which didn't account for the timing of focus changes.

### New Behavior
Mouse capture is automatically restored when the window receives focus (WM_SETFOCUS), as long as the game is in a state where capture should be active (game started, no menu displayed, no screen overlay).

### Fix Implementation
Added a WM_SETFOCUS message handler in Windows64_Minecraft.cpp that:
```
	case WM_SETFOCUS:
		{
			Minecraft *pMinecraft = Minecraft::GetInstance();
			bool shouldCapture = pMinecraft && app.GetGameStarted() && !ui.GetMenuDisplayed(0) && pMinecraft->screen == NULL;
			if (shouldCapture)
				KMInput.SetCapture(true);
		}
		break;
```

## Changes
Fix 2: Static Initialization Order Fiasco in Packet.cpp

### Previous Behavior
The game crashed with heap corruption errors (read access violation, _free_dbg failures) due to corrupted unordered_set static members in Packet.cpp.

### Root Cause
Static variables were explicitly initialized with temporary objects:

unordered_set<int> Packet::sendToAnyClientPackets = unordered_set<int>();
This triggers copy/move construction, which can fail if the static initialization order across translation units is undefined. The container's internal state becomes corrupted (null bucket pointers, garbage addresses like 0x11101110111037A).

### New Behavior
Static containers use default initialization without explicit temporaries, ensuring proper zero-initialization before any static constructor runs.

### Fix Implementation
Changed in Packet.cpp:
```
// Before:
unordered_set<int> Packet::sendToAnyClientPackets = unordered_set<int>();

// After:
unordered_set<int> Packet::sendToAnyClientPackets;
```

Related Issues
- Fixes heap corruption crashes during static initialization
- Fixes mouse capture loss after alt+tab (common issue in Windows64 builds)

Testing
- Mouse capture: Alt+tab out and back, or click from another window → mouse is immediately captured without ESC
- Static initialization: No more read access violation in _Find_last or _free_dbg crashes