### PR TITLE
Any Aspect Ratio support with dynamic window resizing

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -84,6 +84,9 @@ BOOL g_bWidescreen = TRUE;
 int g_iScreenWidth = 1920;
 int g_iScreenHeight = 1080;
 
+UINT g_ScreenWidth = 1920;
+UINT g_ScreenHeight = 1080;
+
 // Fullscreen toggle state
 static bool g_isFullscreen = false;
 static WINDOWPLACEMENT g_wpPrev = { sizeof(g_wpPrev) };
@@ -425,7 +428,90 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			return TRUE;
 		}
 		return DefWindowProc(hWnd, message, wParam, lParam);
+	case WM_SIZE:
+	{
+		if (wParam == SIZE_MINIMIZED)
+			return 0;
 
+		UINT width = LOWORD(lParam);
+		UINT height = HIWORD(lParam);
+
+		if (width == 0 || height == 0)
+			return 0;
+
+		g_ScreenWidth = width;
+		g_ScreenHeight = height;
+
+		if (g_pSwapChain)
+		{
+			g_pImmediateContext->OMSetRenderTargets(0, 0, 0);
+			g_pImmediateContext->ClearState();
+			g_pImmediateContext->Flush();
+
+			if (g_pRenderTargetView)
+			{
+				g_pRenderTargetView->Release();
+				g_pRenderTargetView = nullptr;
+			}
+
+			if (g_pDepthStencilView)
+			{
+				g_pDepthStencilView->Release();
+				g_pDepthStencilView = nullptr;
+			}
+
+			if (g_pDepthStencilBuffer)
+			{
+				g_pDepthStencilBuffer->Release();
+				g_pDepthStencilBuffer = nullptr;
+			}
+
+			HRESULT hr = g_pSwapChain->ResizeBuffers(
+				0,
+				width,
+				height,
+				DXGI_FORMAT_UNKNOWN,
+				0
+			);
+
+			if (FAILED(hr))
+			{
+				app.DebugPrintf("ResizeBuffers Failed! HRESULT: 0x%X\n", hr);
+				return 0;
+			}
+
+			ID3D11Texture2D* pBackBuffer = nullptr;
+			g_pSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&pBackBuffer);
+
+			g_pd3dDevice->CreateRenderTargetView(pBackBuffer, NULL, &g_pRenderTargetView);
+			pBackBuffer->Release();
+
+			D3D11_TEXTURE2D_DESC descDepth = {};
+			descDepth.Width = width;
+			descDepth.Height = height;
+			descDepth.MipLevels = 1;
+			descDepth.ArraySize = 1;
+			descDepth.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+			descDepth.SampleDesc.Count = 1;
+			descDepth.BindFlags = D3D11_BIND_DEPTH_STENCIL;
+
+			g_pd3dDevice->CreateTexture2D(&descDepth, NULL, &g_pDepthStencilBuffer);
+			g_pd3dDevice->CreateDepthStencilView(g_pDepthStencilBuffer, NULL, &g_pDepthStencilView);
+
+			g_pImmediateContext->OMSetRenderTargets(1, &g_pRenderTargetView, g_pDepthStencilView);
+
+			D3D11_VIEWPORT vp = {};
+			vp.Width = (FLOAT)width;
+			vp.Height = (FLOAT)height;
+			vp.MinDepth = 0.0f;
+			vp.MaxDepth = 1.0f;
+			vp.TopLeftX = 0;
+			vp.TopLeftY = 0;
+
+			g_pImmediateContext->RSSetViewports(1, &vp);
+		}
+	}
+	break;
 	default:
 		return DefWindowProc(hWnd, message, wParam, lParam);
 	}

--- a/Minecraft.Client/glWrapper.cpp
+++ b/Minecraft.Client/glWrapper.cpp
@@ -48,9 +48,13 @@ void glLoadIdentity()
 	RenderManager.MatrixSetIdentity();
 }
 
+extern UINT g_ScreenWidth;
+extern UINT g_ScreenHeight;
+
 void gluPerspective(float fovy, float aspect, float zNear, float zFar)
 {
-	RenderManager.MatrixPerspective(fovy,aspect,zNear,zFar);
+	float dynamicAspect = (float)g_ScreenWidth / (float)g_ScreenHeight;
+	RenderManager.MatrixPerspective(fovy, dynamicAspect, zNear, zFar);
 }
 
 void glOrtho(float left,float right,float bottom,float top,float zNear,float zFar)


### PR DESCRIPTION
# Pull Request

## Description
This PR adds the ability to resize the window while keeping the 3D environment rendering at the correct aspect ratio (not stretched out or squished)

This allows any aspect ratio, both ultrawide and taller ones like 4:3 or even subtle changes like 16:10 for steam deck. 

Video demo:
https://www.youtube.com/watch?v=Q860euK_zMU

*Note, this has been fully tested after implementing to this repo*

## Changes

### Previous Behavior
Previously, resizing the window causes the game to look stretched out, which is ugly to play with.

### Root Cause
The reason for this is it was hardcoded to support 16:9 or 4:3 aspect ratios based on the device and video mode, with Windows64 target only using 16:9. 

### New Behavior
Now, the aspect ratio changes in real time as you resize the game. 

### Fix Implementation
The perspective in glWrapper takes in an aspect ratio variable, that was always being passed as 16:9. My implementation updates this to set new variables for the window width and height every time the window is resized, and then use those to calculate the new aspect ratio and pass it in to be rendered.

### Known Issues
This fix looks a lot better when stretching out windows, fixing the 3D environment from being stretched, but not the UI components, rendered via SWF flash files, target 16:9 (there are four types of each UI, 480p for 4:3, 720/1080p for 16:9 which the latter is used, and PS Vita which are a bit skinnier than 16:9, I imagine 16:10). 

The actual screen size variables in this PR could be used to letterbox/pillarbox the SWF screens dynamically with whitespace, but I couldn't get that part working. Nonetheless, this is a much better implementation of window resizing than default.

## Related Issues
- Fixes #165
