### PR TITLE
Cleaner implementation of support dynamic resizing aspect ratio

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -431,14 +431,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			return TRUE;
 		}
 		return DefWindowProc(hWnd, message, wParam, lParam);
-	case WM_SIZE:
-	{
-		// Set the screen width and height used for calculating the aspect ratio
-		g_iScreenWidth = LOWORD(lParam);
-		g_iScreenHeight = HIWORD(lParam);
-		app.DebugPrintf("width: %d, height: %d\n", g_iScreenWidth, g_iScreenHeight);
-	}
-	break;
 	default:
 		return DefWindowProc(hWnd, message, wParam, lParam);
 	}


### PR DESCRIPTION
## Description
This re-adds the dynamic aspect ratio scaling of the 3d environment with a simpler approach.

I've opened this as a draft so testing can be done on wine/Linux environments to ensure compatibility first.

Video showing it working in CrossOver on Mac: 
https://imgur.com/a/6XHePYi

## Changes

### Previous Behavior
Stretching a window for ultrawide resolutions causes the game the look stretched out. 

### New Behavior
This PR fixes the window squishing/stretching by making the 3d rendering look correct based on the current window size.

### Root Cause
The previous issue seemed to do with memory management. I was creating a local value to map the window size to, then releasing it, but it caused some issues forWine/Linux users.

### Fix Implementation
Now the implementation is quite simple. The window values are now directly referenced in the WM_SIZE case, and set to the window size, then the aspect ratio is calculated in glWrapper.

Additionally, instead of using new unsigned ints, the original window size ints are used, which also means that this value does not need to be set on init.

## Related Issues
- Fixes #222
