### PR TITLE
feat: bind F1 to toggle the HUD settings

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -1272,7 +1272,15 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 			}
 		}
 
-		// F3 toggles the debug console overlay, F11 toggles fullscreen
+		// F1 toggles the HUD, F3 toggles the debug console overlay, F11 toggles fullscreen
+		if (KMInput.IsKeyPressed(VK_F1))
+		{
+			int primaryPad = ProfileManager.GetPrimaryPad();
+			unsigned char displayHud = app.GetGameSettings(primaryPad, eGameSetting_DisplayHUD);
+			app.SetGameSettings(primaryPad, eGameSetting_DisplayHUD, displayHud ? 0 : 1);
+			app.SetGameSettings(primaryPad, eGameSetting_DisplayHand, displayHud ? 0 : 1);
+		}
+		
 		if (KMInput.IsKeyPressed(VK_F3))
 		{
 			static bool s_debugConsole = false;

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This feature is based on [LCEMP](https://github.com/LCEMP/LCEMP/)
 - **Select Item**: `Mouse Wheel` or keys `1` to `9`
 - **Accept or Decline Tutorial hints**: `Enter` to accept and `B` to decline
 - **Game Info (Player list and Host Options)**: `TAB`
+- **Toggle HUD**: `F1`
 - **Toggle Debug Info**: `F3`
 - **Open Debug Overlay**: `F4`
 


### PR DESCRIPTION
# Pull Request

## Description
This simply toggles the "Display HUD" and "Display Hand" settings when you press F1 to be consistent with Java Edition.

## Changes

### Previous Behavior
F1 was not bound to anything.

### New Behavior
Pressing F1 now sets the Display HUD and Display Hand game settings to the opposite of whatever Display HUD was.