### PR TITLE
chunk optimization

### DIFF
--- a/Minecraft.Client/LevelRenderer.cpp
+++ b/Minecraft.Client/LevelRenderer.cpp
@@ -1964,8 +1964,8 @@ bool LevelRenderer::updateDirtyChunks()
 						{
 							if( (!onlyRebuild) ||
 								globalChunkFlags[ pClipChunk->globalIdx ] & CHUNK_FLAG_COMPILED ||
-								( distSq < 20 * 20 ) )	// Always rebuild really near things or else building (say) at tower up into empty blocks when we are low on memory will not create render data
-							{
+								( distSq < 96 * 96 ) )	// Always rebuild really near things or else building (say) at tower up into empty blocks when we are low on memory will not create render data
+							{	// distSq adjusted from 20 * 20 to 96 * 96 - updated by detectiveren
 								considered++;
 								// Is this chunk nearer than our nearest?
 #ifdef _LARGE_WORLDS

--- a/Minecraft.Client/LevelRenderer.h
+++ b/Minecraft.Client/LevelRenderer.h
@@ -58,8 +58,10 @@ public:
 	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 448 * 1024 * 1024;		// 4J - added - hard limit is 512 so giving a lot of headroom here for fragmentation (have seen 16MB lost to fragmentation in multiplayer crash dump before)
 #elif defined __PS3__
 	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 110 * 1024 * 1024;		// 4J - added
+#elif defined _WINDOWS64
+	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 2047 * 1024 * 1024; // added by Twest
 #else
-	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 55 * 1024 * 1024;		// 4J - added
+	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 55 * 1024 * 1024;		// 4J - added 
 #endif
 public:
 	LevelRenderer(Minecraft *mc, Textures *textures);
@@ -270,10 +272,10 @@ public:
 
 	bool				dirtyChunkPresent;
 	__int64				lastDirtyChunkFound;
-	static const int	FORCE_DIRTY_CHUNK_CHECK_PERIOD_MS = 250;
+	static const int	FORCE_DIRTY_CHUNK_CHECK_PERIOD_MS = 125; // decreased from 250 to 125 - updated by detectiveren
 
 #ifdef _LARGE_WORLDS
-	static const int MAX_CONCURRENT_CHUNK_REBUILDS = 4;
+	static const int MAX_CONCURRENT_CHUNK_REBUILDS = 8; // increased from 4 to 8 - updated by detectiveren
 	static const int MAX_CHUNK_REBUILD_THREADS = MAX_CONCURRENT_CHUNK_REBUILDS - 1;
 	static Chunk permaChunk[MAX_CONCURRENT_CHUNK_REBUILDS];
 	static C4JThread *rebuildThreads[MAX_CHUNK_REBUILD_THREADS];


### PR DESCRIPTION
## Description
Makes chunks load a bit faster, it should be treated as a temp fix for now.

## Changes
Increased the amount of chunk rebuilding around the player up to 6 chunks.

### Previous Behavior
Chunks would load at a slow pace that in creative mode even the player flying could get ahead of chunk loading

### Root Cause
The values for specific variables that influence chunk rendering were low for modern hardware standards.

### New Behavior
Chunks should load a bit more faster around the player and the player shouldn't be able to get ahead of chunk rendering.

### Fix Implementation
Increased the values for dirty chunk check periods, concurrent chunk rebuilds, chunks that can render within distance from the player and command buffer allocations.

Credit to @twest0001 as they discovered that increasing MAX_COMMANDBUFFER_ALLOCATIONS from 55 * 1024 * 1024 to 2047 * 1024 * 1024 makes chunks load a bit faster too.  That is included in this PR along with my changes.

## Related Issues
- Related to #54 
