### PR TITLE
Separate _WINDOWS64 and _XBOX_ONE

### DIFF
--- a/Minecraft.Client/LevelRenderer.h
+++ b/Minecraft.Client/LevelRenderer.h
@@ -52,8 +52,10 @@ public:
 	static const int CHUNK_SIZE = 16;
 #endif
 	static const int CHUNK_Y_COUNT = Level::maxBuildHeight / CHUNK_SIZE;
-#if (defined _XBOX_ONE || defined _WINDOWS64)
-	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 2047 * 1024 * 1024;		// Changed to 2047. 4J had set to 512.
+#if defined _WINDOWS64
+	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 2047 * 1024 * 1024;	// Changed to 2047. 4J had set to 512.
+#elif defined _XBOX_ONE
+	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 512 * 1024 * 1024;		// 4J - added
 #elif defined __ORBIS__
 	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 448 * 1024 * 1024;		// 4J - added - hard limit is 512 so giving a lot of headroom here for fragmentation (have seen 16MB lost to fragmentation in multiplayer crash dump before)
 #elif defined __PS3__


### PR DESCRIPTION
# Pull Request

## Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

## Description
Briefly describe the changes this PR introduces. 

## Changes

### Previous Behavior
*Describe how the code behaved before this change.*

### Root Cause
https://github.com/smartcmd/MinecraftConsoles/pull/246#issuecomment-3988809632

### New Behavior
*Describe how the code behaves after this change.*

### Fix Implementation
Simply gave each one a separate definition and set the _XBOX_ONE one to its original value.

## Related Issues
- Related to #246 
