### PR TITLE
#221: Fix menu glitch.

### DIFF
--- a/Minecraft.Client/Windows64/KeyboardMouseInput.cpp
+++ b/Minecraft.Client/Windows64/KeyboardMouseInput.cpp
@@ -103,6 +103,7 @@ void KeyboardMouseInput::OnRawMouseInput(LPARAM lParam)
 
 void KeyboardMouseInput::OnMouseButton(int button, bool down)
 {
+	if (ui.IsPauseMenuDisplayed(ProfileManager.GetPrimaryPad())) { return; }
 	if (button >= 0 && button < 3)
 	{
 		if (down && !m_mouseButtons[button]) m_mousePressedAccum[button] = true;


### PR DESCRIPTION
# Pull Request


## Description
Fixes a pause menu bug where mouse clicks accumulated while the game was paused. 

## Changes

### Previous Behavior
Before, the game would recognize clicks made even when your game was paused, and execute them when it was unpaused. 
[Video of the previous behaviour (you can't see them, but I am M1 clicking while the pause menu is up!)
](https://streamable.com/no7y3t)
### Root Cause
The function ``KeyboardMouseInput::OnMouseButton`` in ``KeyboardMouseInput.cpp`` would accumulate clicks all the time, even while the game was paused,  that were picked up by ``Minecraft.cpp``, line 3512:
```cpp
|| (iPad == 0 && KMInput.IsCaptured() && KMInput.IsMouseDown(0))
```

### New Behavior
Now, the game (in reference to ``Minecraft.cpp``), when unpaused, only acknowledges clicks that were made when the game was unpaused, not ones that were made when the game was paused. 
[Video of the current behaviour (same deal as above)](https://streamable.com/cn49hu)

### Fix Implementation
Adding a check for ``ConsoleUIController::IsPauseMenuDisplayed()`` in ``KeyboardMouseInput`` prevents it from logging clicks made when the game is paused. 
```cpp
if (ui.IsPauseMenuDisplayed(ProfileManager.GetPrimaryPad())) { return; }
```

_Side note: There is likely a better way to access this behaviour (i.e., exposing a flag as part of ConsoleUIController rather than activating this function per click), however, I did not find any such existing behaviour while investigating this bug, and didn't want to jump the gun by implementing it before proper planning._
## Related Issues
- Fixes #221 
