### PR TITLE
feat: make the game sensitivity slider affect mouse sensitivity

### DIFF
--- a/Minecraft.Client/Input.cpp
+++ b/Minecraft.Client/Input.cpp
@@ -145,7 +145,7 @@ void Input::tick(LocalPlayer *player)
 		// Delta should normally be 0 since applyFrameMouseLook() already consumed it
 		if (rawDx != 0.0f || rawDy != 0.0f)
 		{
-			float mouseSensitivity = 0.5f;
+			float mouseSensitivity = ((float)app.GetGameSettings(iPad, eGameSetting_Sensitivity_InGame)) / 100.0f;
 			float mdx = rawDx * mouseSensitivity;
 			float mdy = -rawDy * mouseSensitivity;
 			if (app.GetGameSettings(iPad, eGameSetting_ControlInvertLook))

--- a/Minecraft.Client/Minecraft.cpp
+++ b/Minecraft.Client/Minecraft.cpp
@@ -1191,7 +1191,7 @@ void Minecraft::applyFrameMouseLook()
 		KMInput.ConsumeMouseDelta(rawDx, rawDy);
 		if (rawDx == 0.0f && rawDy == 0.0f) continue;
 
-		float mouseSensitivity = 0.5f;
+		float mouseSensitivity = ((float)app.GetGameSettings(iPad, eGameSetting_Sensitivity_InGame)) / 100.0f;
 		float mdx = rawDx * mouseSensitivity;
 		float mdy = -rawDy * mouseSensitivity;
 		if (app.GetGameSettings(iPad, eGameSetting_ControlInvertLook))


### PR DESCRIPTION
# Pull Request

## Description
This sets mouse sensitivity to the value of the "Game Sensitivity" setting. Video: https://youtu.be/aUyH_F1Mqoo

## Changes

### Previous Behavior
The game sensitivity setting only affected looking around with a controller, not mouse input.

### Root Cause
The mouse sensitivity variable was set to a flat number (`0.5f`).

### New Behavior
The game sensitivity setting now affects mouse input.

## Related Issues
- Fixes @Lexiosity's comments in #128 and #141
- Fixes part of #250