### PR TITLE
Add `.clang-format` based on the style 4J seemed to use (#30)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,55 @@
+---
+BasedOnStyle: Microsoft
+AccessModifierOffset: -2
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+ColumnLimit: 0
+IncludeBlocks: Preserve
+IndentAccessModifiers: false
+IndentCaseBlocks: true
+IndentCaseLabels: false
+IndentExportBlock: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentWidth: 4
+InsertBraces: true
+InsertNewlineAtEOF: true
+NamespaceIndentation: None
+PointerAlignment: Right
+RemoveParentheses: Leave
+RemoveSemicolon: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:
+  Enabled: true
+  IgnoreCase: false
+SpacesInParens: Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts: false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: Latest
+TabWidth: 4
+UseTab: Never


### PR DESCRIPTION
# Pull Request

## Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

## Description
This PR adds a `.clang-format` file that while might not be perfect (the source files did not seem to have consistent formatting to begin with) attempts to lock in the major coding style choices from the original 4J code (4-space indents, C#/Allman style braces).

The style 4J used seems to be based on the Microsoft style (presumably the default settings of whatever Visual Studio they used to write this). However, the source files do not have much consistency so I highly doubt 4J cared too much about styling, just going with whatever happened to be the default. So I think mainly sticking to the Microsoft style should be fine.

## Changes

### Previous Behavior
The coding style was kinda all over the place with `Texture.cpp` for instance using hard tabs and other files using spaces.

### Root Cause
No `.clang-format` or any consistent style from 4J to begin with.

### New Behavior
There is now a consistent coding style.

### Fix Implementation
By adding a `.clang-format` file.

## Related Issues
- Fixes #30
