### PR TITLE
Remove duplicate elif from LevelRender.h

### DIFF
--- a/Minecraft.Client/LevelRenderer.h
+++ b/Minecraft.Client/LevelRenderer.h
@@ -60,8 +60,6 @@ public:
 	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 448 * 1024 * 1024;		// 4J - added - hard limit is 512 so giving a lot of headroom here for fragmentation (have seen 16MB lost to fragmentation in multiplayer crash dump before)
 #elif defined __PS3__
 	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 110 * 1024 * 1024;		// 4J - added
-#elif defined _WINDOWS64
-	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 2047 * 1024 * 1024; // added by Twest
 #else
 	static const int MAX_COMMANDBUFFER_ALLOCATIONS = 55 * 1024 * 1024;		// 4J - added 
 #endif


### PR DESCRIPTION
# Pull Request

## Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

## Description
Removes the duplicate _WINDOWS64 line in LevelRenderer.h.

## Changes

### Previous Behavior
There are two entries for _WINDOWS64 in the aformentioned file. Luckily they're exactly identical so no real issues would manifest.

### Root Cause
Oversight

### New Behavior
No real change besides addressing the oversight.

### Fix Implementation
Literally just the description.
