### PR TITLE
Fix ender dragon hit not making left side red

### DIFF
--- a/Minecraft.Client/EnderDragonRenderer.cpp
+++ b/Minecraft.Client/EnderDragonRenderer.cpp
@@ -77,12 +77,7 @@ void EnderDragonRenderer::renderModel(shared_ptr<LivingEntity> _mob, float wp, f
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		glColor4f(1, 0, 0, 0.5f);
-#ifdef __PSVITA__
-		// AP - not sure that the usecompiled flag is supposed to be false. This makes it really slow on vita. Making it true still seems to look the same
 		model->render(mob, wp, ws, bob, headRotMinusBodyRot, headRotx, scale, true);
-#else
-		model->render(mob, wp, ws, bob, headRotMinusBodyRot, headRotx, scale, false);
-#endif
 		glEnable(GL_TEXTURE_2D);
 		glDisable(GL_BLEND);
 		glDepthFunc(GL_LEQUAL);


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

## Description
Fix ender dragon hit not making left side red

## Changes

### Previous Behavior
The left side of the ender dragon didnt go red when hit
<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/33e00ce9-d351-42f6-922b-0e6f01c9a7e4" />

### Root Cause
This was due to the renderer when being hit not using `usecompiled=true`

### New Behavior
Always set `usecompiled` to `true`
<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/c0961730-669a-4e0e-8b37-d1ebfdfff75e" />

### Fix Implementation
Change argument and remove PSVITA check