### PR TITLE
Fix ability to fly down while in a menu

### DIFF
--- a/Minecraft.Client/Minecraft.cpp
+++ b/Minecraft.Client/Minecraft.cpp
@@ -1456,7 +1456,7 @@ void Minecraft::run_middle()
 						if (KMInput.ConsumeKeyPress('C'))         localplayers[i]->ullButtonsPressed |= 1LL<<MINECRAFT_ACTION_CRAFTING;
 						if (KMInput.ConsumeKeyPress(VK_F5))       localplayers[i]->ullButtonsPressed |= 1LL<<MINECRAFT_ACTION_RENDER_THIRD_PERSON;
 						// In flying mode, Shift held = sneak/descend
-						if (localplayers[i]->abilities.flying && KMInput.IsKeyDown(VK_SHIFT))
+						if (localplayers[i]->abilities.flying && KMInput.IsKeyDown(VK_SHIFT) && !ui.GetMenuDisplayed(i))
 							localplayers[i]->ullButtonsPressed |= 1LL<<MINECRAFT_ACTION_SNEAK_TOGGLE;
 					}
 #endif


### PR DESCRIPTION
## Description
Prevents the player from using Shift to fly down while in a menu (e.g. Inventory), only affects while flying in Creative mode.

## Changes

### Previous Behavior
When a menu was open, like the Inventory, holding shift would still cause the player to fly down in the background.

### Root Cause
In `Minecraft::run_middle()`, a check is done to see if the user is flying (`localplayers[i]->abilities.flying`) and holding Shift on the keyboard (`KMInput.IsKeyDown(VK_SHIFT)`), but the logic does not account for a menu to be open.
Full line:
`if (localplayers[i]->abilities.flying && KMInput.IsKeyDown(VK_SHIFT))
	localplayers[i]->ullButtonsPressed |= 1LL<<MINECRAFT_ACTION_SNEAK_TOGGLE;`

### New Behavior
The `if` statement now accounts for menus open in the UI system, using a function provided by the system. This now prevents being able to fly down while a menu is open.

### Fix Implementation
An additional check has been added to this statement which the fly down action is *not* performed if `ui.GetMenuDisplayed(i)` is true.
New line:
`if (localplayers[i]->abilities.flying && KMInput.IsKeyDown(VK_SHIFT) && !ui.GetMenuDisplayed(i))
	localplayers[i]->ullButtonsPressed |= 1LL<<MINECRAFT_ACTION_SNEAK_TOGGLE;`

## Related Issues
- Fixes #299 
