### PR TITLE
fix: properly offset the mouse position in containers

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene_AbstractContainerMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_AbstractContainerMenu.cpp
@@ -209,8 +209,8 @@ void UIScene_AbstractContainerMenu::tick()
 			scrollDelta = KMInput.ConsumeScrollDelta();
 
 			// Convert mouse position to movie coordinates using the movie/client ratio
-			float mx = (float)mouseX * ((float)m_movieWidth / (float)clientWidth);
-			float my = (float)mouseY * ((float)m_movieHeight / (float)clientHeight);
+			float mx = (float)mouseX * ((float)m_movieWidth / (float)clientWidth) - (float)m_controlMainPanel.getXPos();
+			float my = (float)mouseY * ((float)m_movieHeight / (float)clientHeight) - (float)m_controlMainPanel.getYPos();
 
 			rawMouseMovieX = mx;
 			rawMouseMovieY = my;
@@ -301,8 +301,13 @@ void UIScene_AbstractContainerMenu::tick()
 		// Scale mouse client coords to the Iggy display space (which was set to getRenderDimensions())
 		RECT clientRect;
 		GetClientRect(KMInput.GetHWnd(), &clientRect);
-		x = (S32)((float)KMInput.GetMouseX() * ((float)width / (float)clientRect.right));
-		y = (S32)((float)KMInput.GetMouseY() * ((float)height / (float)clientRect.bottom));
+		float mouseMovieX = (float)KMInput.GetMouseX() * ((float)m_movieWidth / (float)clientRect.right);
+		float mouseMovieY = (float)KMInput.GetMouseY() * ((float)m_movieHeight / (float)clientRect.bottom);
+		float mouseLocalX = mouseMovieX - (float)m_controlMainPanel.getXPos();
+		float mouseLocalY = mouseMovieY - (float)m_controlMainPanel.getYPos();
+
+		x = (S32)(mouseLocalX * ((float)width / m_movieWidth));
+		y = (S32)(mouseLocalY * ((float)height / m_movieHeight));
 	}
 	else
 	{


### PR DESCRIPTION
## Description
This offsets the mouse position in containers so it's at the correct location on the screen. Video: https://www.youtube.com/watch?v=cBJgRcisq60

## Changes

### Previous Behavior
The mouse could not move past the left or top edges of containers without going outside the window.

### Root Cause
The mouse position was simply multiplied by the movie/client ratio with no offset.

### New Behavior
The mouse is now at the correct location anywhere on the screen, including past the left or top edges of containers. It's also centered properly when opening containers.

### Fix Implementation
The X and Y position of `m_controlMainPanel` is subtracted from the mouse position. There might be a better way of doing this, but this seems to work just fine.