### PR TITLE
Fix Texture Pack images in menu

### DIFF
--- a/Minecraft.Client/Common/UI/UIController.cpp
+++ b/Minecraft.Client/Common/UI/UIController.cpp
@@ -1445,7 +1445,7 @@ GDrawTexture * RADLINK UIController::TextureSubstitutionCreateCallback ( void * 
 
 			// 4J Stu - All our flash controls that allow replacing textures use a special 64x64 symbol
 			// Force this size here so that our images don't get scaled wildly
-	#if (defined __ORBIS__ || defined _DURANGO )
+	#if (defined __ORBIS__ || defined _DURANGO || defined _WINDOWS64 )
 			*width = 96;
 			*height = 96;
 	#else


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

## Description
Add _WINDOWS64 to the HD platform check for substitution texture sizes so icons display correctly.

## Changes

### Previous Behavior
<img width="1920" height="1080" alt="Screenshot_4" src="https://github.com/user-attachments/assets/ee909ec5-03f5-4dae-b13c-caef9ab9b415" />

### Root Cause
_WINDOWS64 was missing from the #if that sets 96×96 for HD platforms. The HD SWF skins on Windows64 use 96×96 icon placeholders, so the 64×64 size caused mismatched scaling.

### New Behavior
<img width="2470" height="1257" alt="7yaKDyB" src="https://github.com/user-attachments/assets/d5e15c94-95b3-49b0-9658-a5e4ecde4546" />

### Fix Implementation
Added `|| defined _WINDOWS64` to the existing `#if (defined __ORBIS__ || defined _DURANGO) `
