### PR TITLE
Fix culling that limited render distance of new chunks

### DIFF
--- a/Minecraft.Client/LevelRenderer.cpp
+++ b/Minecraft.Client/LevelRenderer.cpp
@@ -2557,12 +2557,18 @@ void LevelRenderer::cull(Culler *culler, float a)
 	{
 		unsigned char flags = pClipChunk->globalIdx == -1 ? 0 : globalChunkFlags[ pClipChunk->globalIdx ];
 
+		// Always perform frustum cull test
+		bool clipres = clip(pClipChunk->aabb, fdraw);
+
 		if ( (flags & CHUNK_FLAG_COMPILED ) && ( ( flags & CHUNK_FLAG_EMPTYBOTH ) != CHUNK_FLAG_EMPTYBOTH ) )
 		{
-			bool clipres = clip(pClipChunk->aabb, fdraw);
 			pClipChunk->visible = clipres;
 			if( pClipChunk->visible ) vis++;
 			total++;
+		}
+		else if (clipres)
+		{
+			pClipChunk->visible = true;
 		}
 		else
 		{
@@ -2571,6 +2577,7 @@ void LevelRenderer::cull(Culler *culler, float a)
 		pClipChunk++;
 	}
 }
+
 
 void LevelRenderer::playStreamingMusic(const wstring& name, int x, int y, int z)
 {


### PR DESCRIPTION
## Description
Fix frustum culling for newly generated chunks so they render to the full render distance limit instead of being  excluded.

## Changes

### Previous Behavior
Only chunks marked with `CHUNK_FLAG_COMPILED` had their visibility explicitly set based on the frustum test. Newly generated chunks relied on a separate condition which did not consistently update `pClipChunk->visible in the same way. This caused new chunks to render at a shorter distance than already compiled one.

### Root Cause
`clip` was performed inside the compiled chunk branch meaning visibility logic differed depending on chunk state. Which cased inconsistent visibility updates causing premature culling of new chunks.

### New Behavior
All chunks now undergo the single frustum test at the start of the block.

### Fix Implementation
- Moved the frustum test outside the compiled chunk branch

## Related Issues
#175 