### PR TITLE
Prevent world input from affecting inventory

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene_AbstractContainerMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_AbstractContainerMenu.cpp
@@ -33,6 +33,11 @@ UIScene_AbstractContainerMenu::UIScene_AbstractContainerMenu(int iPad, UILayer *
 	m_bHasMousePosition = false;
 	m_lastMouseX = 0;
 	m_lastMouseY = 0;
+
+	for (int btn = 0; btn < 3; btn++)
+	{
+		KMInput.ConsumeMousePress(btn);
+	}
 #endif
 }
 


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

## Description
Prevents world input from affecting inventory

## Changes

### Previous Behavior
The hotbar gets cleared if you right click and then open the creative inventory

### Root Cause
The `UIScene_AbstractContainerMenu` was not clearing the input buffer during its construction

### New Behavior
Menus now start with a clean slate. When any container menu is opened, all mouse button states are reset. The player must release and click again to perform any action inside the UI, ensuring no accidental interactions occur during the transition.

### Fix Implementation
Modified the `UIScene_AbstractContainerMenu` constructor implementing a loop that calls `KMInput.ConsumeMousePress(btn)` for the mouse buttons (0, 1, and 2) during initialization.

## Related Issues
- Fixes #312 
