### PR TITLE
Update crafting controls description

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This feature is based on [LCEMP](https://github.com/LCEMP/LCEMP/)
 - **Sprint**: `Ctrl` (Hold) or Double-tap `W`
 - **Inventory**: `E`
 - **Drop Item**: `Q`
-- **Crafting**: `C`
+- **Crafting**: `C` Use `Q` and `E` to move through tabs (cycles Left/Right)
 - **Toggle View (FPS/TPS)**: `F5`
 - **Fullscreen**: `F11`
 - **Pause Menu**: `Esc`


### PR DESCRIPTION
# Documentation update: Clarified menu controls.

## Description
This PR updates the `README.md` to clarify keyboard menu navigation.

## Changes

### Previous Behavior
The README lacked instructions for cycling through tabs in the Crafting and Inventory menus using the keyboard.

### New Behavior
The README now explicitly states that `Q` and `E` are used for tab navigation in menus.

### Fix Implementation
- Modified `README.md` to include "- **Crafting**: `C` Use `Q` and `E` to move through tabs (cycles Left/Right)"