### PR TITLE
Fix exceptions when exiting after opening world.

### DIFF
--- a/Minecraft.Client/Chunk.cpp
+++ b/Minecraft.Client/Chunk.cpp
@@ -103,7 +103,7 @@ void Chunk::setPos(int x, int y, int z)
 	// 4J - changed to just set the value rather than make a new one, if we've already created storage
 	if( bb == NULL )
 	{
-		bb = shared_ptr<AABB>(AABB::newPermanent(-g, -g, -g, XZSIZE+g, SIZE+g, XZSIZE+g));
+		bb = std::shared_ptr<AABB>(AABB::newPermanent(-g, -g, -g, XZSIZE+g, SIZE+g, XZSIZE+g));
 	}
  	else 
  	{

--- a/Minecraft.Client/Chunk.h
+++ b/Minecraft.Client/Chunk.h
@@ -47,7 +47,7 @@ public:
     int xRenderOffs, yRenderOffs, zRenderOffs;
  
     int xm, ym, zm;
-    shared_ptr<AABB> bb;
+    std::shared_ptr<AABB> bb;
 	ClipChunk *clipChunk;
 
     int id;


### PR DESCRIPTION
## Description
Changes chunks to use unique pointers

## Changes
Changes to `chunk.h` and `chunk.cpp`

### Previous Behavior
Exception spam after exiting if a world was opened.

### Root Cause
Chunk bounding box was shared between multiple chunks causing it to be deleted multiple times.

### New Behavior
unique pointer handles it itself.

### Fix Implementation
Change bounding box to be unique_ptr and fix functions that broke from the type change.

## Related Issues
I didn't check
