### PR TITLE
Fix creative inventory crash with Art Tools debug option

### DIFF
--- a/Minecraft.Client/Common/UI/IUIScene_CreativeMenu.cpp
+++ b/Minecraft.Client/Common/UI/IUIScene_CreativeMenu.cpp
@@ -882,7 +882,7 @@ void IUIScene_CreativeMenu::TabSpec::populateMenu(AbstractContainerMenu *menu, i
 	for(; currentGroup < m_staticGroupsCount; ++currentGroup)
 	{
 		int size = categoryGroups[m_staticGroupsA[currentGroup]].size();
-		if( currentIndex + size < startIndex)
+		if( currentIndex + size <= startIndex)
 		{
 			currentIndex += size;
 			continue;
@@ -932,7 +932,7 @@ void IUIScene_CreativeMenu::TabSpec::populateMenu(AbstractContainerMenu *menu, i
 			for(; currentGroup < m_debugGroupsCount; ++currentGroup)
 			{
 				int size = categoryGroups[m_debugGroupsA[currentGroup]].size();
-				if( currentIndex + size < startIndex)
+				if( currentIndex + size <= startIndex)
 				{
 					currentIndex += size;
 					continue;
@@ -973,7 +973,9 @@ unsigned int IUIScene_CreativeMenu::TabSpec::getPageCount()
 #ifndef _CONTENT_PACKAGE
 	if(app.DebugArtToolsOn())
 	{
-		return (int)ceil((float)(m_staticItems + m_debugItems) / m_staticPerPage);
+		int totalItems = m_staticItems + m_debugItems;
+		const int totalRows = (totalItems + columns - 1) / columns;
+		return std::max<int>(1, totalRows - rows + 1);
 	}
 	else
 #endif


### PR DESCRIPTION
Fix vector out-of-bounds crash when scrolling the potions tab in the creative inventory with Art Tools debug enabled.

- Fix getPageCount() returning total rows instead of scrollable pages in Art Tools mode

- Fix off-by-one boundary check in populateMenu() for both static and debug group loops (< should be <=)

## Description
Fix crash (`vector subscript out of range`) when scrolling the potions/brewing tab in the creative inventory with the "Art Tools" debug option enabled.

## Changes

### Previous Behavior
Scrolling down in the potions tab of the creative inventory with the Art Tools debug setting enabled caused a `Debug Assertion Failed: vector subscript out of range` crash.

### Root Cause
Two bugs in `IUIScene_CreativeMenu.cpp`:

1. `getPageCount()` returned total rows instead of scrollable pages in Art Tools mode. The formula `ceil((m_staticItems + m_debugItems) / m_staticPerPage)` did not subtract the 5 visible rows, allowing scrolling beyond the valid item range.

2. Off-by-one in `populateMenu()` boundary checks (lines 885 and 935) used `<` instead of `<=`. When `startIndex` aligned exactly with a group boundary, `currentItem` was set to `size` (one past the last valid index), causing the out-of-bounds access.

### New Behavior
The potions tab scrolls correctly with Art Tools enabled without crashing. Page count is calculated consistently with the non-debug formula.

### Fix Implementation
- `getPageCount()`: Replaced `ceil(total / perPage)` with `max(1, totalRows - rows + 1)` to match the existing page calculation.
- `populateMenu()` line 885: Changed `currentIndex + size < startIndex` to `<=` so group boundaries are handled correctly.
- `populateMenu()` line 935: Same fix for the debug groups loop.

## Related Issues
- Fixes #386
