### PR TITLE
fix #397 server console

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,6 @@ target_compile_definitions(MinecraftClient PRIVATE
 )
 if(MSVC)
   configure_msvc_target(MinecraftClient)
-  # Use CONSOLE subsystem so the shell waits for the process (important for
-  # Docker and piped output in server mode).  WinMainCRTStartup keeps the
-  # WinMain entry point.  Client mode calls FreeConsole() to detach.
   target_link_options(MinecraftClient PRIVATE
     /SUBSYSTEM:CONSOLE
     /ENTRY:WinMainCRTStartup

--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -228,10 +228,7 @@ static BOOL WINAPI HeadlessServerCtrlHandler(DWORD ctrlType)
 
 static void SetupHeadlessServerConsole()
 {
-	// The exe is linked as /SUBSYSTEM:CONSOLE, so it normally inherits the
-	// parent's console.  However, if launched with DETACHED_PROCESS or
-	// CREATE_NO_WINDOW the handles may be invalid.  Verify before redirecting
-	// the CRT streams to avoid leaving them in a broken state.
+	// Verify console handles are valid before redirecting CRT streams
 	HANDLE hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
 	HANDLE hStdIn  = GetStdHandle(STD_INPUT_HANDLE);
 	bool hasConsole =


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

> I got lazy and had AI (`Grok Code Fast 1`) generate this, but it is ACURATE and VERIFIED

## Description
Forces the terminal instance of the server to be prioritized, if you launch the server via a shortcut or similar it will be detached into its own window. This is critical for running the server in Docker containers or any environment where stdout/stderr must stay attached to the calling process.

## Changes

### Previous Behavior
<img width="1623" height="659" alt="image" src="https://github.com/user-attachments/assets/f8c5ebdd-3b9c-4d9a-a261-7b72b7360374" />

When running `MinecraftClient.exe -server` from a terminal, the process would immediately return control to the shell. Server output would appear interleaved with new shell prompts, and the server ran fully detached — making it unusable in Docker containers or piped output scenarios.

### Root Cause
The executable was linked with `/SUBSYSTEM:WINDOWS` (via CMake's `add_executable(... WIN32 ...)`), which tells the OS it is a GUI application. Shells (PowerShell, cmd, Docker entrypoints) do **not** wait for GUI-subsystem processes to exit — they return the prompt immediately. Additionally, `SetupHeadlessServerConsole()` called `AllocConsole()` unconditionally, which always creates a **new** detached console window rather than inheriting the parent's console.

### New Behavior
<img width="1155" height="526" alt="{AE9E5684-C910-4ECC-A85D-130CB95D4D90}" src="https://github.com/user-attachments/assets/f18bacb0-d46d-44bd-ada4-34c0c7978e3e" />

Running `MinecraftClient.exe -server` now blocks the calling shell until the server exits. All stdout/stderr output flows through the inherited console. In client mode (no `-server` flag), the console is silently detached via `FreeConsole()` so there is no visible console window — identical to the previous client experience.

### Fix Implementation
Three targeted changes across two files:

1. **`CMakeLists.txt`** — Added `/SUBSYSTEM:CONSOLE /ENTRY:WinMainCRTStartup` linker flags. This switches the PE subsystem to CONSOLE (so the OS makes shells wait for the process) while preserving the `WinMain` entry point via the explicit `/ENTRY` override.

2. **`Windows64_Minecraft.cpp` — `SetupHeadlessServerConsole()`** — Removed the `AllocConsole()` call. Since the exe is now a CONSOLE subsystem app, it automatically inherits the parent's console. The function now only re-opens the CRT streams (`stdin`/`stdout`/`stderr`) to point at the console and registers the Ctrl+C handler.

3. **`Windows64_Minecraft.cpp` — `_tWinMain()`** — Added a `FreeConsole()` call early in startup when `-server` is **not** present. This detaches the inherited console in client mode so no console window is visible during normal gameplay.

## Related Issues
- Related to #397 