### PR TITLE
Fix Chunk destructor segfault using smart pointers #112

### DIFF
--- a/Minecraft.Client/Chunk.cpp
+++ b/Minecraft.Client/Chunk.cpp
@@ -52,7 +52,7 @@ Chunk::Chunk(Level *level, LevelRenderer::rteMap &globalRenderableTileEntities, 
 	: globalRenderableTileEntities( &globalRenderableTileEntities ), globalRenderableTileEntities_cs(&globalRenderableTileEntities_cs)
 {
 	clipChunk->visible = false;
-	bb = NULL;
+	bb = nullptr;
 	id = 0;
 
 	this->level = level;
@@ -101,15 +101,15 @@ void Chunk::setPos(int x, int y, int z)
 
 	float g = 6.0f;
 	// 4J - changed to just set the value rather than make a new one, if we've already created storage
-	if( bb == NULL )
+	if( !bb )
 	{
-		bb = AABB::newPermanent(-g, -g, -g, XZSIZE+g, SIZE+g, XZSIZE+g);
+		bb = shared_ptr<AABB>(AABB::newPermanent(-g, -g, -g, XZSIZE+g, SIZE+g, XZSIZE+g));
 	}
- 	else 
- 	{
+	else 
+	{
 		// 4J MGH - bounds are relative to the position now, so the AABB will be setup already, either above, or from the tesselator bounds.
 // 		bb->set(-g, -g, -g, SIZE+g, SIZE+g, SIZE+g);
- 	}
+	}
 	clipChunk->aabb[0] = bb->x0 + x;
 	clipChunk->aabb[1] = bb->y0 + y;
 	clipChunk->aabb[2] = bb->z0 + z;
@@ -154,6 +154,7 @@ void Chunk::translateToPos()
 
 Chunk::Chunk()
 {
+	bb = nullptr;
 }
 
 void Chunk::makeCopyForRebuild(Chunk *source)
@@ -998,7 +999,7 @@ int Chunk::getList(int layer)
 
 void Chunk::cull(Culler *culler)
 {
-	clipChunk->visible = culler->isVisible(bb);
+	clipChunk->visible = culler->isVisible(bb.get());
 }
 
 void Chunk::renderBB()
@@ -1027,10 +1028,7 @@ void Chunk::clearDirty()
 #endif
 }
 
-Chunk::~Chunk()
-{
-	delete bb;
-}
+Chunk::~Chunk() = default;
 
 bool Chunk::emptyFlagSet(int layer)
 {

--- a/Minecraft.Client/Chunk.h
+++ b/Minecraft.Client/Chunk.h
@@ -46,11 +46,11 @@ public:
     int xRender, yRender, zRender;
     int xRenderOffs, yRenderOffs, zRenderOffs;
  
-    int xm, ym, zm;
-    AABB *bb;
+	int xm, ym, zm;
+	shared_ptr<AABB> bb;
 	ClipChunk *clipChunk;
 
-    int id;
+	int id;
 //public:
 //	vector<shared_ptr<TileEntity> > renderableTileEntities;		// 4J - removed
     


### PR DESCRIPTION
## Description
This PR fixes a seg-fault that occurs when exiting the game after loading a world. The exception was triggered inside `Chunk::~Chunk` due to a double free of the AABB bounding box pointer. The fix migrates the raw `AABB*` to a `shared_ptr<AABB>`  and removes the manual delete logic.

## Changes

### Previous Behavior
- Chunk used a raw pointer
- `bb` was allocated via `AABB::newPermanent` but also freed manually in `Chunk::~Chunk`.
- Some engine systems also referenced the same AABB. causing an eventual double-free during shutdown.
- Exiting a world triggered a crash inside _free_dbg when `bb` was deleted twice.

### Root Cause
The root cause was mismatched ownership and lifetime management of the AABB instance. `AABB::newPermanet` returns an object expected to be globally persistent or managed elsewhere, but `Chunk` unconditionally deleted it in its destructor. When the engine`s global destructors ran later, the same memory was freed again causing the seg-fault.

### New Behavior
- Chunk now stores `bb` using `shared_ptr<AABB>`.
- The destructor uses `= default` removing manual deletion.
- `cull` now correctly passes `bb.get` when a raw pointer is required. 

### Fix Implementation
- Replaced `AABB* bb` with `shared_ptr<ABB> bb`
- Updated construction.
- Removed manual memory management.
- Adjusted `cull`.
- Initialized `bb = nullptr` in the default constructor.

## Related Issues
#112 
#380 
