### PR TITLE
Fix Item First-Person Swing Animation

### DIFF
--- a/Minecraft.Client/ItemInHandRenderer.cpp
+++ b/Minecraft.Client/ItemInHandRenderer.cpp
@@ -548,7 +548,7 @@ void ItemInHandRenderer::render(float a)
         glPushMatrix();
         float d = 0.8f;
 
-#if defined __ORBIS__ || defined __PS3__
+#if defined __ORBIS__ || defined __PS3__ || defined _WINDOWS64
 		static const float swingPowFactor = 1.0f;
 #else
 		static const float swingPowFactor = 4.0f;		// 4J added, to slow the swing down when nearest the player for avoiding luminance flash issues


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

## Description
<!-- Briefly describe the changes this PR introduces. -->
This PR corrects the Swing animation speed.

## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->
Previously, the animation would be slower.
Old arm swing animation (video): https://github.com/user-attachments/assets/a4136199-cb9f-4ef7-aac8-6e1aac9d890d

### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->
<img width="1480" height="104" alt="image" src="https://github.com/user-attachments/assets/c7396bbd-9233-43e6-97ae-ed73c2343f77" />
Previously, the `defined _WINDOWS64` was not there, which meant the console edition was using the slower cooldown on windows. The comment states that the reason for it being there on non-hd consoles is due to issues with composite/component signals and fast animations which would cause flickering.

### New Behavior
<!-- Describe how the code behaves after this change. -->
New arm swing animation (video): https://github.com/user-attachments/assets/b3caba29-a6a2-4b59-9cc2-56614e4b7e0a

### Fix Implementation
Adding `defined _WINDOWS64` ensures that it builds with regular speed for PC.
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->

### Room for Improvement
- Could be made into a toggleable option

## Related Issues
- Related to #289