### PR TITLE
Prevent door sounds from playing twice #392

### DIFF
--- a/Minecraft.Client/MultiPlayerGameMode.cpp
+++ b/Minecraft.Client/MultiPlayerGameMode.cpp
@@ -370,7 +370,9 @@ bool MultiPlayerGameMode::useItemOn(shared_ptr<Player> player, Level *level, sha
 		// are meant to be directly caused by this. If we don't do this, then the sounds never happen as the tile's use method is only called on the
 		// server, and that won't allow any sounds that are directly made, or broadcast back level events to us that would make the sound, since we are
 		// the source of the event.
-		if( ( t > 0 ) && ( !bTestUseOnly ) && player->isAllowedToUse(Tile::tiles[t]) )
+		// ---------------------------------------------------------------------------------
+		// Only call soundOnly version if we didn't already call the tile's use method above
+		if( !didSomething && ( t > 0 ) && ( !bTestUseOnly ) && player->isAllowedToUse(Tile::tiles[t]) )
 		{
 			Tile::tiles[t]->use(level, x, y, z, player, face, clickX, clickY, clickZ, true);
 		}


### PR DESCRIPTION
## Description
This PR fixes an issue where right clicking doors (and other tiles) caused their sound to play twice.

## Changes

### Previous Behavior
When a player used an interactable tile, the game would call the tile's `use` method when the action modified state `(didSomething == true)`, and call the `soundOnly` version afterward regardless. This resulted in duplicate sound events.

### Root Cause
The fallback 'soundOnly' call did not check whether the tile's main `use` method had already been invoked. As a result the sound even ran twice once during the actual interaction and once during the fallback.

### New Behavior
The fallback sound invocatoin now occurs only when no primary interaction happened `(!didSomething`. This prevents duplicate sound triggers.

### Fix Implementation
A simple guard condition was added. 

## Related Issues
#392 
