### PR TITLE
Fix duplicated stained glass when art tools enabled

### DIFF
--- a/Minecraft.Client/Common/UI/IUIScene_CreativeMenu.cpp
+++ b/Minecraft.Client/Common/UI/IUIScene_CreativeMenu.cpp
@@ -263,40 +263,6 @@ void IUIScene_CreativeMenu::staticCtor()
 			BuildFirework(list, FireworksItem::TYPE_CREEPER, DyePowderItem::BLUE, 1, true, false);
 			BuildFirework(list, FireworksItem::TYPE_STAR, DyePowderItem::YELLOW, 1, false, false);
 			BuildFirework(list, FireworksItem::TYPE_BIG, DyePowderItem::WHITE, 1, true, true);
-
-			ITEM_AUX(Tile::stained_glass_Id,14)	// Red
-			ITEM_AUX(Tile::stained_glass_Id,1)	// Orange
-			ITEM_AUX(Tile::stained_glass_Id,4)	// Yellow
-			ITEM_AUX(Tile::stained_glass_Id,5)	// Lime
-			ITEM_AUX(Tile::stained_glass_Id,3)	// Light Blue
-			ITEM_AUX(Tile::stained_glass_Id,9)	// Cyan
-			ITEM_AUX(Tile::stained_glass_Id,11)	// Blue
-			ITEM_AUX(Tile::stained_glass_Id,10)	// Purple
-			ITEM_AUX(Tile::stained_glass_Id,2)	// Magenta
-			ITEM_AUX(Tile::stained_glass_Id,6)	// Pink
-			ITEM_AUX(Tile::stained_glass_Id,0)	// White
-			ITEM_AUX(Tile::stained_glass_Id,8)	// Light Gray
-			ITEM_AUX(Tile::stained_glass_Id,7)	// Gray
-			ITEM_AUX(Tile::stained_glass_Id,15)	// Black
-			ITEM_AUX(Tile::stained_glass_Id,13)	// Green
-			ITEM_AUX(Tile::stained_glass_Id,12)	// Brown
-
-			ITEM_AUX(Tile::stained_glass_pane_Id,14)	// Red
-			ITEM_AUX(Tile::stained_glass_pane_Id,1)	// Orange
-			ITEM_AUX(Tile::stained_glass_pane_Id,4)	// Yellow
-			ITEM_AUX(Tile::stained_glass_pane_Id,5)	// Lime
-			ITEM_AUX(Tile::stained_glass_pane_Id,3)	// Light Blue
-			ITEM_AUX(Tile::stained_glass_pane_Id,9)	// Cyan
-			ITEM_AUX(Tile::stained_glass_pane_Id,11)	// Blue
-			ITEM_AUX(Tile::stained_glass_pane_Id,10)	// Purple
-			ITEM_AUX(Tile::stained_glass_pane_Id,2)	// Magenta
-			ITEM_AUX(Tile::stained_glass_pane_Id,6)	// Pink
-			ITEM_AUX(Tile::stained_glass_pane_Id,0)	// White
-			ITEM_AUX(Tile::stained_glass_pane_Id,8)	// Light Gray
-			ITEM_AUX(Tile::stained_glass_pane_Id,7)	// Gray
-			ITEM_AUX(Tile::stained_glass_pane_Id,15)	// Black
-			ITEM_AUX(Tile::stained_glass_pane_Id,13)	// Green
-			ITEM_AUX(Tile::stained_glass_pane_Id,12)	// Brown
 		}
 #endif
 


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

## Description
Removes duplicated stained glass from the creative inventory when "Art Tools" are enabled.

## Changes

### Previous Behavior
In the Creative Inventory, stained glass appeared twice when the "Art Tools" option was toggled on

### Root Cause
The stained glass was being registered to the creative category twice: once in the standard block registration and again inside the "Art Tools" conditional check

### New Behavior
Stained glass now appears only once in the creative inventory

### Fix Implementation
Removed stained glass from the art tools section

## Related Issues
- Fixes #413 
