### PR TITLE
Fix incorrect distance comparison return value #417

### DIFF
--- a/Minecraft.World/NearestAttackableTargetGoal.cpp
+++ b/Minecraft.World/NearestAttackableTargetGoal.cpp
@@ -34,7 +34,7 @@ bool NearestAttackableTargetGoal::DistComp::operator() (shared_ptr<Entity> e1, s
 	double distSqr2 = source->distanceToSqr(e2);
 	if (distSqr1 < distSqr2) return true;
 	if (distSqr1 > distSqr2) return false;
-	return true;
+	return false;
 }
 
 NearestAttackableTargetGoal::NearestAttackableTargetGoal(PathfinderMob *mob, const type_info& targetType, int randomInterval, bool mustSee, bool mustReach /*= false*/, EntitySelector *entitySelector /* =NULL */)


### PR DESCRIPTION
## Description
Fixes an incorrect return value in the distance comparator used by `NearestAttackableTargetGoal`, which caused crashes during wolf target selection.

## Changes

### Previous Behavior
When two distances were equal the comparator returned true, breaking the weak ordering required by STL containers and causing wolf attack crashes.

### Root Cause
The comparator treated equal distances as '<`.

### New Behavior
Equal distance now correctly return false.

### Fix Implementation
Replaced the final `return true;` with `return false;` in `DistComp::operator()`.

## Related Issues
- Fixes #417 