### PR TITLE
Center inventory menu panel on screen

### DIFF
--- a/Minecraft.Client/Common/UI/UIControl.cpp
+++ b/Minecraft.Client/Common/UI/UIControl.cpp
@@ -104,6 +104,20 @@ S32 UIControl::getHeight()
 	return m_height;
 }
 
+bool UIControl::setXPos(S32 x)
+{
+	rrbool succ = IggyValueSetF64RS(getIggyValuePath(), m_nameXPos, NULL, (F64)x);
+	if (succ) m_x = x;
+	return succ;
+}
+
+bool UIControl::setYPos(S32 y)
+{
+	rrbool succ = IggyValueSetF64RS(getIggyValuePath(), m_nameYPos, NULL, (F64)y);
+	if (succ) m_y = y;
+	return succ;
+}
+
 void UIControl::setOpacity(float percent)
 {
 	if(percent != m_lastOpacity)

--- a/Minecraft.Client/Common/UI/UIControl.h
+++ b/Minecraft.Client/Common/UI/UIControl.h
@@ -80,6 +80,8 @@ public:
 	S32 getYPos();
 	S32 getWidth();
 	S32 getHeight();
+	bool setXPos(S32 x);
+	bool setYPos(S32 y);
 
 	void setOpacity(float percent);
 	void setVisible(bool visible);

--- a/Minecraft.Client/Common/UI/UIScene_InventoryMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_InventoryMenu.cpp
@@ -38,6 +38,7 @@ UIScene_InventoryMenu::UIScene_InventoryMenu(int iPad, void *_initData, UILayer 
 	initData->player->awardStat(GenericStats::openInventory(),GenericStats::param_openInventory());
 
 	Initialize( initData->iPad, menu, false, InventoryMenu::INV_SLOT_START, eSectionInventoryUsing, eSectionInventoryMax, initData->bNavigateBack );
+	applyMenuOffset();
 
 	m_slotListArmor.addSlots(InventoryMenu::ARMOR_SLOT_START, InventoryMenu::ARMOR_SLOT_END - InventoryMenu::ARMOR_SLOT_START);
 
@@ -67,6 +68,7 @@ wstring UIScene_InventoryMenu::getMoviePath()
 void UIScene_InventoryMenu::handleReload()
 {
 	Initialize( m_iPad, m_menu, false, InventoryMenu::INV_SLOT_START, eSectionInventoryUsing, eSectionInventoryMax, m_bNavigateBack );
+	applyMenuOffset();
 
 	m_slotListArmor.addSlots(InventoryMenu::ARMOR_SLOT_START, InventoryMenu::ARMOR_SLOT_END - InventoryMenu::ARMOR_SLOT_START);
 
@@ -74,6 +76,21 @@ void UIScene_InventoryMenu::handleReload()
 	{
 		m_bEffectTime[i] = 0;
 	}
+}
+
+void UIScene_InventoryMenu::applyMenuOffset()
+{
+	// Center the inventory background panel in the movie viewport.
+	const int bgWidth = m_controlBackgroundPanel.getWidth();
+	const int bgHeight = m_controlBackgroundPanel.getHeight();
+	const int bgLocalX = m_controlBackgroundPanel.getXPos();
+	const int bgLocalY = m_controlBackgroundPanel.getYPos();
+
+	const int targetBgX = (m_movieWidth - bgWidth) / 2;
+	const int targetBgY = (m_movieHeight - bgHeight) / 2;
+
+	m_controlMainPanel.setXPos(targetBgX - bgLocalX);
+	m_controlMainPanel.setYPos(targetBgY - bgLocalY);
 }
 
 int UIScene_InventoryMenu::getSectionColumns(ESceneSection eSection)

--- a/Minecraft.Client/Common/UI/UIScene_InventoryMenu.h
+++ b/Minecraft.Client/Common/UI/UIScene_InventoryMenu.h
@@ -48,4 +48,5 @@ protected:
 
 private:
 	void updateEffectsDisplay();
+	void applyMenuOffset();
 };


### PR DESCRIPTION
## Summary
This PR centers the Inventory menu panel in the viewport instead of relying on static authored placement.

## What changed
- Added runtime centering for inventory UI in the inventory scene.
- Added reusable UI control position setters used by the centering logic.

## Testing
- Built MinecraftClient in Release successfully.
- Manually verified inventory panel positioning behavior.