### PR TITLE
Fix mob nametag position to match correct height offset #422

### DIFF
--- a/Minecraft.Client/LivingEntityRenderer.cpp
+++ b/Minecraft.Client/LivingEntityRenderer.cpp
@@ -487,11 +487,11 @@ void LivingEntityRenderer::renderNameTag(shared_ptr<LivingEntity> mob, const wst
 
 	Font *font = getFont();
 
-	float size = 1.60f;
-	float s = 1 / 60.0f * size;
+    constexpr float size = 1.60f;
+    constexpr float s = 1 / 60.0f * size;
 
 	glPushMatrix();
-	glTranslatef((float) x + 0, (float) y + 2.3f, (float) z);
+	glTranslatef(static_cast<float>(x) + 0, static_cast<float>(y) + mob->bbHeight + 0.5f, static_cast<float>(z));
 	glNormal3f(0, 1, 0);
 
 	glRotatef(-this->entityRenderDispatcher->playerRotY, 0, 1, 0);


### PR DESCRIPTION
## Description
Adjust mob nametag position so it renders above the mob's actual height instead of using the player offset.

## Changes

### Previous Behavior
Mob nametags were positioned at the same v-offset as players nametags, causing them to float to high.

### Root Cause
The nametag translation used a hardcoded + 2.3f player offset instead of the mov's bounding box height.

### New Behavior
Nametags render slightly above the mob's real height.

### Fix Implementation
- Updated the Y translation to use `mob->bbHeight + 0.5f` instead of a fixed value.
- Converted literals to `constexpr` and used `static_cast<flaot>` instead of C-Style casts.

## Related Issues
- Fixes #422 

Yet another small change 😅😭.