### PR TITLE
Persist fullscreen setting and start windowed mode maximized

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -124,6 +124,50 @@ static void CopyWideArgToAnsi(LPCWSTR source, char* dest, size_t destSize)
 	dest[destSize - 1] = 0;
 }
 
+// ---------- Persistent options (options.txt next to exe) ----------
+static void GetOptionsFilePath(char *out, size_t outSize)
+{
+	GetModuleFileNameA(NULL, out, (DWORD)outSize);
+	char *p = strrchr(out, '\\');
+	if (p) *(p + 1) = '\0';
+	strncat_s(out, outSize, "options.txt", _TRUNCATE);
+}
+
+static void SaveFullscreenOption(bool fullscreen)
+{
+	char path[MAX_PATH];
+	GetOptionsFilePath(path, sizeof(path));
+	FILE *f = nullptr;
+	if (fopen_s(&f, path, "w") == 0 && f)
+	{
+		fprintf(f, "fullscreen=%d\n", fullscreen ? 1 : 0);
+		fclose(f);
+	}
+}
+
+static bool LoadFullscreenOption()
+{
+	char path[MAX_PATH];
+	GetOptionsFilePath(path, sizeof(path));
+	FILE *f = nullptr;
+	if (fopen_s(&f, path, "r") == 0 && f)
+	{
+		char line[256];
+		while (fgets(line, sizeof(line), f))
+		{
+			int val = 0;
+			if (sscanf_s(line, "fullscreen=%d", &val) == 1)
+			{
+				fclose(f);
+				return val != 0;
+			}
+		}
+		fclose(f);
+	}
+	return false;
+}
+// ------------------------------------------------------------------
+
 static void ApplyScreenMode(int screenMode)
 {
 	switch (screenMode)
@@ -664,7 +708,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 		return FALSE;
 	}
 
-	ShowWindow(g_hWnd, nCmdShow);
+	ShowWindow(g_hWnd, (nCmdShow != SW_HIDE) ? SW_SHOWMAXIMIZED : nCmdShow);
 	UpdateWindow(g_hWnd);
 
 	return TRUE;
@@ -873,6 +917,7 @@ void ToggleFullscreen()
 			SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
 	}
 	g_isFullscreen = !g_isFullscreen;
+	SaveFullscreenOption(g_isFullscreen);
 
 	if (g_KBMInput.IsWindowFocused())
 		g_KBMInput.SetWindowFocused(true);
@@ -1191,6 +1236,12 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	{
 		CleanupDevice();
 		return 0;
+	}
+
+	// Restore fullscreen state from previous session
+	if (LoadFullscreenOption() && !g_isFullscreen)
+	{
+		ToggleFullscreen();
 	}
 
 	if (launchOptions.serverMode)


### PR DESCRIPTION
## Description
Persist the fullscreen toggle state across game restarts and start the window maximized when in windowed mode.

## Changes

### Previous Behavior
- Toggling fullscreen with F11 only lasted for the current session. On the next launch, the game always started in windowed mode regardless of the user's last fullscreen setting.
- When starting in windowed mode, the window opened at a non-maximized size, requiring the user to manually maximize it.

### Root Cause
`g_isFullscreen` was hardcoded to `false` on line 98 of `Windows64_Minecraft.cpp` and was never saved to disk. The `ToggleFullscreen()` function only modified the in-memory variable without any persistence. There was also no mechanism to read a saved fullscreen preference on startup.

### New Behavior
- The fullscreen state is saved to `options.txt` (next to the executable) whenever F11 is pressed. On the next launch, the saved state is read and applied after window creation.
- When the game starts in windowed mode, the window is now shown maximized by default.

### Fix Implementation
- Added `SaveFullscreenOption()` and `LoadFullscreenOption()` helper functions that read/write a simple `fullscreen=1` or `fullscreen=0` key-value pair to `options.txt` (following the same pattern as the existing `username.txt`).
- `ToggleFullscreen()` now calls `SaveFullscreenOption()` after toggling the state.
- In `_tWinMain()`, after `InitDevice()` completes, `LoadFullscreenOption()` is called and `ToggleFullscreen()` is invoked if the saved state is fullscreen.
- Changed `ShowWindow()` in `InitInstance()` to use `SW_SHOWMAXIMIZED` instead of the default `nCmdShow` for non-hidden windows.

## Related Issues
- Fixes #391