### PR TITLE
Add servers.txt so players can add an arbitrary amount of servers to the "Join Game" list

### DIFF
--- a/Minecraft.Client/Common/Network/PlatformNetworkManagerStub.cpp
+++ b/Minecraft.Client/Common/Network/PlatformNetworkManagerStub.cpp
@@ -701,6 +701,7 @@ void CPlatformNetworkManagerStub::SearchForGames()
 #ifdef _WINDOWS64
 	std::vector<Win64LANSession> lanSessions = WinsockNetLayer::GetDiscoveredSessions();
 
+	//THEY GET DELETED HERE DAMMIT
 	for (size_t i = 0; i < friendsSessions[0].size(); i++)
 		delete friendsSessions[0][i];
 	friendsSessions[0].clear();
@@ -757,7 +758,7 @@ void CPlatformNetworkManagerStub::SearchForGames()
 				name = wline;
 				phase = 0;
 
-				//I assume it gets deleted later down the line, otherwise why would REVs be thrown?
+				//THEY GET DELETED AFTER USE LIKE 30 LINES UP!!
 				FriendSessionInfo* info = new FriendSessionInfo();
 				wchar_t label[128];
 				wcsncpy_s(label, sizeof(label)/sizeof(wchar_t), name.c_str(), _TRUNCATE);


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

## Description
Allows players to define server entries in `servers.txt` (located in the folder of the running EXE)

## Changes
Added code that reads `servers.txt` and adds defined servers to the list
The text file is defined as follows:
```
<ip>
<port>
<display name>
```
and it can have this as many times as one wants.
Example `servers.txt` file:
```
155.212.208.147
25565
Dryk server!
26.31.243.15
25565
Sus server
127.0.0.1
25565
Lokale host tm
```
This produces the following result:
<img width="762" height="582" alt="image" src="https://github.com/user-attachments/assets/681550d6-f2e3-44ef-8dbf-445df6728da4" />

### Previous Behavior
<!-- Describe how the code behaved before this change. -->
Previously, the join game list only displayed local LAN connectables with no way for the user to direct connect to other servers.

### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->
No input for the player to add servers

### New Behavior
<!-- Describe how the code behaves after this change. -->
The player can define server entries in `servers.txt` and they will be added to the Join Game list

**IMPORTANT: I added `#ifdef _WINDOWS64` as I am not sure how this behaves on other platforms!**
Please act accordingly.

### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->
First, the game checks for the text file, and if it exists, iterates over each line parsing it as `ip`-`port`-`name` until the file ends
Everytime `name` is parsed it adds the information to the list!

## Related Issues
There are no related issues i think
