### PR TITLE
Fix creeper model levitating (#469)

### DIFF
--- a/Minecraft.Client/CreeperModel.cpp
+++ b/Minecraft.Client/CreeperModel.cpp
@@ -6,35 +6,33 @@
 // 4J - added
 void CreeperModel::_init(float g)
 {
-    int yo = 4;
-
     head = new ModelPart(this, 0, 0);
     head->addBox(-4, - 8, -4, 8, 8, 8, g); // Head
-    head->setPos(0, (float)(yo), 0);
+    head->setPos(0, 6, 0);
 
     hair = new ModelPart(this, 32, 0);
     hair->addBox(-4, -8, -4, 8, 8, 8, g + 0.5f); // Head
-    hair->setPos(0, (float)(yo), 0);
+    hair->setPos(0, 6, 0);
 
     body = new ModelPart(this, 16, 16);
     body->addBox(-4, 0, -2, 8, 12, 4, g); // Body
-    body->setPos(0, (float)(yo), 0);
+    body->setPos(0, 6, 0);
 
     leg0 = new ModelPart(this, 0, 16);
     leg0->addBox(-2, 0, -2, 4, 6, 4, g); // Leg0
-    leg0->setPos(-2, (float)(12 + yo), 4);
+    leg0->setPos(-2, 18, 4);
 
     leg1 = new ModelPart(this, 0, 16);
     leg1->addBox(-2, 0, -2, 4, 6, 4, g); // Leg1
-    leg1->setPos(2, (float)(12 + yo), 4);
+    leg1->setPos(2, 18, 4);
 
     leg2 = new ModelPart(this, 0, 16);
     leg2->addBox(-2, 0, -2, 4, 6, 4, g); // Leg2
-    leg2->setPos(-2, (float)(12 + yo), -4);
+    leg2->setPos(-2, 18, -4);
 
     leg3 = new ModelPart(this, 0, 16);
     leg3->addBox(-2, 0, -2, 4, 6, 4, g); // Leg3
-    leg3->setPos(2, (float)(12 + yo), -4);
+    leg3->setPos(2, 18, -4);
 
 	// 4J added - compile now to avoid random performance hit first time cubes are rendered
 	head->compile(1.0f/16.0f);


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

## Description
<!-- Briefly describe the changes this PR introduces. -->
Fixes the y offset for the creeper model.

## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->
Creeper model appeared slightly off the ground.

### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->
y offset variable being added to all model parts' y position was off by 2 units.

### New Behavior
<!-- Describe how the code behaves after this change. -->
Creeper model renders correctly on the ground.

### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->
Inlined the y offset variable into the y pos for each model part. Also removed unnecessary float casts.

## Related Issues
- Fixes #469

Before:
<img width="729" height="650" alt="Screenshot 2026-03-04 183744" src="https://github.com/user-attachments/assets/82a45ff3-f60d-4a88-a395-db77110a3c3b" />

After:
<img width="778" height="663" alt="Screenshot 2026-03-04 183946" src="https://github.com/user-attachments/assets/066a7687-c8c9-42f6-821e-9110ef36f689" />

