### PR TITLE
Fix Unwanted pause from exiting In-Game Menus

### DIFF
--- a/Minecraft.Client/Minecraft.cpp
+++ b/Minecraft.Client/Minecraft.cpp
@@ -1485,7 +1485,7 @@ void Minecraft::run_middle()
 						}
 
 						// Utility keys always work regardless of KBM active state
-						if(g_KBMInput.IsKeyPressed(KeyboardMouseInput::KEY_PAUSE) && !ui.IsTutorialVisible(i))
+						if(g_KBMInput.IsKeyPressed(KeyboardMouseInput::KEY_PAUSE) && !ui.IsTutorialVisible(i) && !ui.GetMenuDisplayed(i))
 						{
 							localplayers[i]->ullButtonsPressed|=1LL<<MINECRAFT_ACTION_PAUSEMENU;
 							app.DebugPrintf("PAUSE PRESSED (keyboard) - ipad = %d\n",i);


### PR DESCRIPTION
## Description
Whenever inside of a UI Menu, pressing escape to back out of the menu can also activate pause within the same key press.
It becomes very noticeable on higher frame rate like 360fps (my refresh rate).
Testing with other people that have similar refresh rates yielded it to be fixed.

## Changes
https://github.com/user-attachments/assets/2215ecc2-69a7-44b5-ac8c-145383d9ece9


### Previous Behavior
Pressing Escape, while in a Container menu like Crafting or Inventory, could cause the pause menu to open directly after.

### Root Cause
Because B and PAUSEMENU weren't meant to be bound to the same button, this allows PAUSEMENU to be pushed directly after exiting a container menu within a keypress.

### New Behavior
Checks whether a Menu is currently not being displayed before pushing ACTION_PAUSEMENU, therefore it cannot directly open the pause menu when exiting UI Menus within the same keypress.

### Fix Implementation
Added `!ui.GetMenuDisplayed(i)`
Here -> `if(g_KBMInput.IsKeyPressed(KeyboardMouseInput::KEY_PAUSE) && !ui.IsTutorialVisible(i) && !ui.GetMenuDisplayed(i))`

## Related Issues
- Related to #401 
