### PR TITLE
Fix beacon crash

### DIFF
--- a/Minecraft.Client/Common/UI/IUIScene_BeaconMenu.cpp
+++ b/Minecraft.Client/Common/UI/IUIScene_BeaconMenu.cpp
@@ -387,8 +387,10 @@ vector<HtmlString> *IUIScene_BeaconMenu::GetSectionHoverText(ESceneSection eSect
 
 			desc = new vector<HtmlString>();
 
-			HtmlString string( app.GetString(MobEffect::effects[effectId]->getDescriptionId()), eHTMLColor_White );
-			desc->push_back( string );
+			if (effectId < MobEffect::e_MobEffectIcon_COUNT && MobEffect::effects[effectId]) {
+				HtmlString string( app.GetString(MobEffect::effects[effectId]->getDescriptionId()), eHTMLColor_White );
+				desc->push_back( string );
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
<!-- 
Note: IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.
-->

## Description
Fixed crash when opening a beacon menu while holding certain items

## Changes

### Previous Behavior
The game would crash immediately when opening a beacon with some items

### Root Cause
The code was attempting to call `MobEffect::effects[effectId]->getDescriptionId()` without verifying if the pointer at effects[effectId] was valid causing a Read Access Violation

### New Behavior
The Beacon menu no longer crashes

### Fix Implementation
Added a safety check in `IUIScene_BeaconMenu::GetSectionHoverText` to ensure `effectId` is within the valid range (using `e_MobEffectIcon_COUNT`) and that the `MobEffect` pointer in the effects array is not null before attempting to access its members.

## Related Issues
- Fixes #503 