### PR TITLE
Fix animals stuck in panic state #514

### DIFF
--- a/Minecraft.World/PanicGoal.cpp
+++ b/Minecraft.World/PanicGoal.cpp
@@ -10,17 +10,24 @@ PanicGoal::PanicGoal(PathfinderMob *mob, double speedModifier)
 {
 	this->mob = mob;
 	this->speedModifier = speedModifier;
-	setRequiredControlFlags(Control::MoveControlFlag);
+    Goal::setRequiredControlFlags(Control::MoveControlFlag);
 }
 
 bool PanicGoal::canUse()
 {
-	if (mob->getLastHurtByMob() == NULL && !mob->isOnFire()) return false;
-	Vec3 *pos = RandomPos::getPos(dynamic_pointer_cast<PathfinderMob>(mob->shared_from_this()), 5, 4);
-	if (pos == NULL) return false;
+	if (mob->getLastHurtByMob() == nullptr && !mob->isOnFire()) return false;
+	const int hurtTimeout = mob->getLastHurtByMobTimestamp();
+	if (hurtTimeout == 0) return false;
+    static thread_local std::mt19937 rng(std::random_device{}());
+	std::uniform_int_distribution<int> dist(60, 100);
+	const int panicDuration = dist(rng);
+	if (mob->tickCount - hurtTimeout > panicDuration) return false;
+	const Vec3* pos = RandomPos::getPos(dynamic_pointer_cast<PathfinderMob>(mob->shared_from_this()), 5, 4);
+	if (pos == nullptr) return false;
 	posX = pos->x;
 	posY = pos->y;
 	posZ = pos->z;
+
 	return true;
 }
 
@@ -31,5 +38,6 @@ void PanicGoal::start()
 
 bool PanicGoal::canContinueToUse()
 {
+	if (mob->getLastHurtByMob() == nullptr && !mob->isOnFire()) return false;
 	return !mob->getNavigation()->isDone();
 }

--- a/Minecraft.World/PanicGoal.h
+++ b/Minecraft.World/PanicGoal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Goal.h"
+#include <random>
 
 class PathfinderMob;
 


### PR DESCRIPTION
## Description
Fixes an issue where animals would remain in the panic state forever after being hit. The panic behavior now expires after 3-5 seconds.

## Changes

### Previous Behavior
After an animal with the panic goal was hit once, it would enter the state and continue running forever until killed.

### Root Cause
The goal didn't have a timeout mechanism that would expire after getting hit like in the base game(s).

### New Behavior
Animals now only remain in the panic state for a randomized about of 60-100 ticks, after which they return back to regular behavior.

### Fix Implementation
- Added logic to check the timestamp of the last damage evnet.
- Introduced a random panic duration.
- The panic goal will now stop activating if the time since the last damage goes past the duration.
- Updated null pointer checks to use `nullptr`.

## Related Issues
- Fixes #514 