### PR TITLE
Fixed stained glass not having the correct names

### DIFF
--- a/Minecraft.World/WoolTileItem.cpp
+++ b/Minecraft.World/WoolTileItem.cpp
@@ -115,6 +115,11 @@ Icon *WoolTileItem::getIcon(int itemAuxValue)
 #ifndef _CONTENT_PACKAGE
 	if(Tile::tiles[id])
 	{
+		if (id == Tile::stained_glass_Id || id == Tile::stained_glass_pane_Id)
+		{
+			return Tile::tiles[id]->getTexture(2, itemAuxValue);
+		}
+
 		return Tile::tiles[id]->getTexture(2, ColoredTile::getTileDataForItemAuxValue(itemAuxValue));
 	}
 	else


### PR DESCRIPTION
## Description
Fixes incorrect stained glass color names.

## Changes

- Corrected stained glass and stained glass pane tooltip color naming.
- Kept existing wool/carpet/clay color behavior unchanged.
- Scoped the fix to item icon metadata handling in `WoolTileItem::getIcon`.

### Previous Behavior
Some stained glass and stained glass pane variants showed mismatched tooltip names (for example, the rendered color and the displayed name did not line up).

### Root Cause
Aux/color metadata was not handled consistently between icon lookup and description lookup for stained glass item variants.

The two paths used different metadata conversion behavior, so color visuals and localized names could get out of sync.

### New Behavior
Stained glass and stained glass pane tooltip names now match the color that is actually rendered in inventory/Creative.

### Fix Implementation
Updated `Minecraft.World/WoolTileItem.cpp` in `WoolTileItem::getIcon(int itemAuxValue)`.

- Added a special case for `Tile::stained_glass_Id` and `Tile::stained_glass_pane_Id`.
- For those two item types, icon lookup now uses `itemAuxValue` directly.

## Related Issues
- Discord Thread : https://discord.com/channels/1478227187843858563/1478921382241767495
