### PR TITLE
fixed delay issue when breaking a block

### DIFF
--- a/Minecraft.Client/MultiPlayerGameMode.cpp
+++ b/Minecraft.Client/MultiPlayerGameMode.cpp
@@ -90,7 +90,6 @@ bool MultiPlayerGameMode::destroyBlock(int x, int y, int z, int face)
 	if (g_NetworkManager.IsHost())
 	{
 		level->levelEvent(LevelEvent::PARTICLES_DESTROY_BLOCK, x, y, z, oldTile->id + (level->getData(x, y, z) << Tile::TILE_NUM_SHIFT));
-		return true;
 	}
 #endif
 


### PR DESCRIPTION
## Description
fixed delay issue when breaking a block

## Previous Behavior
Previously, MultiPlayerGameMode::destroyBlock returned early on the host after spawning block breaking particles, skipping the actual block removal. This caused a delay where the block appeared to remain solid for a moment.

## Video (credits to [codeHusky](https://github.com/codeHusky) for the vid):

https://github.com/user-attachments/assets/18aade2d-42df-403e-8181-29f1458f5274

## Root Cause
MultiPlayerGameMode::destroyBlock returned early

## New Behavior
lets MultiPlayerGameMode::destroyBlock actaully continue

https://github.com/user-attachments/assets/d168c79c-0f9d-4b26-8ca2-0845cccc2921
