### PR TITLE
Fix crash when dispensing a filled bucket into a solid block

### DIFF
--- a/Minecraft.World/ItemDispenseBehaviors.cpp
+++ b/Minecraft.World/ItemDispenseBehaviors.cpp
@@ -288,9 +288,9 @@ shared_ptr<ItemInstance> FilledBucketDispenseBehavior::execute(BlockSource *sour
 		return dispensed;
 	}
 
-	return DefaultDispenseItemBehavior::dispense(source, dispensed);
+	outcome = LEFT_ITEM;
+	return dispensed;
 }
-
 
 /* EmptyBucket */
 


### PR DESCRIPTION
## Description
This pull request fixes a bug where dispensing filled buckets into solid objects causes a crash.

## Changes
Updated the dispense outcome in `FilledBucketDispenseBehavior` to `LEFT_ITEM` if dispensing fails. Also changed the return to `return dispensed;` instead of `DefaultDispenseItemBehavior::dispense(source, dispensed);`.

## Previous Behavior
When dispensing a filled bucket into a solid block, the game crashed.

## Root Cause
The root cause was `FilledBucketDispenseBehavior::execute` returning `DefaultDispenseItemBehavior::dispense(source, dispensed);`, where it should have returned the dispensed item instead.

## New Behavior
The game no longer crashes when dispensing a filled bucket into a solid block.

## Fix Implementation
Return the `dispensed` parameter instead of calling `DefaultDispenseItemBehavior::dispense`. Also changed the outcome to `LEFT_ITEM` to prevent dispense particles from appearing.

## Related Issues
* Fixes #496
* Related to #496
