### PR TITLE
Fix music disc sound leaking across dimensions

### DIFF
--- a/Minecraft.Client/ClientConnection.cpp
+++ b/Minecraft.Client/ClientConnection.cpp
@@ -2694,6 +2694,10 @@ void ClientConnection::handleRespawn(shared_ptr<RespawnPacket> packet)
 		int oldDimension = minecraft->localplayers[m_userIndex]->dimension;
 		started = false;
 
+		// Stop any streaming music (e.g. jukebox) when changing dimensions
+		// so it doesn't leak into the new dimension
+		level->playStreamingMusic(L"", 0, 0, 0);
+
 		// Remove client connection from this level
 		level->removeClientConnection(this, false);
 


### PR DESCRIPTION
Stop streaming music (jukebox) when the player changes dimensions so music disc sounds from the overworld cannot be heard in the nether or vice versa.

Previously, the streaming audio continued playing at its original world coordinates even after a dimension change, causing the sound to leak into the new dimension at the same position.

## Description
Fix music disc audio from jukeboxes leaking across dimensions. When a player enters a portal while a music disc is playing, the sound now correctly stops instead of continuing in the new dimension.

## Changes

### Previous Behavior
When a music disc was playing in a jukebox in the overworld and the player traveled to the nether (or vice versa), the 3D positional audio continued playing at the same world coordinates in the new dimension. The player could hear the music disc in the nether at the corresponding position.

### Root Cause
The `handleRespawn()` function in `ClientConnection.cpp` handles dimension changes but never stopped the streaming audio. The jukebox uses `playStreamingMusic()` with 3D positional audio, and since it was never explicitly stopped during a dimension transition, the audio sample kept playing at its original coordinates regardless of which dimension the player was in.

### New Behavior
When the player changes dimensions, any active streaming music (jukebox) is stopped by calling `level->playStreamingMusic(L"", 0, 0, 0)` before the dimension transition. The music disc sound is no longer audible in the new dimension.

### Fix Implementation
Added a single call to `level->playStreamingMusic(L"", 0, 0, 0)` at the beginning of the dimension change block in `ClientConnection::handleRespawn()`, before the client connection is removed from the current level. Passing an empty string stops any active streaming audio, matching the existing pattern used when a record is ejected from a jukebox.

## Related Issues
- Fixes #411