### PR TITLE
Remove Xbox from version string

### DIFF
--- a/Minecraft.Client/ClientConstants.cpp
+++ b/Minecraft.Client/ClientConstants.cpp
@@ -1,4 +1,4 @@
 #include "stdafx.h"
 #include "ClientConstants.h"
 
-const wstring ClientConstants::VERSION_STRING = wstring(L"Minecraft Xbox ") + VER_FILEVERSION_STR_W;//+ SharedConstants::VERSION_STRING;
+const wstring ClientConstants::VERSION_STRING = wstring(L"Minecraft ") + VER_FILEVERSION_STR_W;//+ SharedConstants::VERSION_STRING;


### PR DESCRIPTION
## Description
Removed Xbox from the version string.

## Changes
Updated VERSION_STRING to be "Minecraft" instead of "Minecraft Xbox".

### Previous Behavior
VERSION_STRING would say "Minecraft Xbox".

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5697df3f-28fd-473e-8dfe-383030a800bc" />

### Root Cause
ClientConstants::VERSION_STRING in ClientConstants.cpp.

### New Behavior
VERSION_STRING now says "Minecraft".

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/af6476ff-fdc3-48c8-a972-0bc73cc5f19f" />

### Fix Implementation
Changed ClientConstants::VERSION_STRING.

## Related Issues
None.
