### PR TITLE
Fix servers.txt by trimming newline from ip

### DIFF
--- a/Minecraft.Client/Common/Network/PlatformNetworkManagerStub.cpp
+++ b/Minecraft.Client/Common/Network/PlatformNetworkManagerStub.cpp
@@ -745,6 +745,8 @@ void CPlatformNetworkManagerStub::SearchForGames()
 		while (std::fgets(buffer, sizeof(buffer), file)) {
 			if (phase == 0) {
 				ip = buffer;
+				if (!ip.empty() && (ip.back() == '\n' || ip.back() == '\r'))
+					ip.pop_back();
 				phase = 1;
 			}
 			else if (phase == 1) {


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Fixes servers.txt entries failing to connect when selected from the join game list

## Changes

### Previous Behavior
Servers added via servers.txt would appear in the join game list but attempting to join them would immediately redirect back to the main menu

### Root Cause
the IP string read from the file via fgets retained its trailing newline character, causing WinsockNetLayer::JoinGame() to fail on the malformed address

### New Behavior
Servers defined in servers.txt can be successfully joined

### Fix Implementation
Strip trailing \n/\r from the IP string after reading it

### AI Use Disclosure
No AI was used in the making of this change

## Related Issues
- Fixes #589

