### PR TITLE
Fixed boats falling and a TP glitch #266

### DIFF
--- a/Minecraft.World/Boat.cpp
+++ b/Minecraft.World/Boat.cpp
@@ -87,7 +87,7 @@ Boat::Boat(Level *level, double x, double y, double z) : Entity( level )
 
 double Boat::getRideHeight()
 {
-	return bbHeight * 0.0f - 0.3f;
+	return heightOffset;
 }
 
 bool Boat::hurt(DamageSource *source, float hurtDamage)
@@ -283,11 +283,11 @@ void Boat::tick()
 
 			// 4J Stu - Fix for #9579 - GAMEPLAY: Boats with a player in them slowly sink under the water over time, and with no player in them they float into the sky.
 			// Just make the boats bob up and down rather than any other client-side movement when not receiving packets from server
-			if (waterPercentage < 1)
-			{
-				double bob = waterPercentage * 2 - 1;
-				yd += 0.04f * bob;
-			}
+	        if (waterPercentage > 0)
+	        {
+		        double bob = waterPercentage * 2 - 1;
+		        yd += 0.04f * bob;
+	        }
 			else
 			{
 				if (yd < 0) yd /= 2;
@@ -307,15 +307,14 @@ void Boat::tick()
 		return;
 	}
 
-	if (waterPercentage < 1)
+	if (waterPercentage > 0)
 	{
 		double bob = waterPercentage * 2 - 1;
 		yd += 0.04f * bob;
 	}
 	else
 	{
-		if (yd < 0) yd /= 2;
-		yd += 0.007f;
+		yd = 0;
 	}
 
 

--- a/Minecraft.World/LivingEntity.cpp
+++ b/Minecraft.World/LivingEntity.cpp
@@ -1305,42 +1305,46 @@ void LivingEntity::teleportTo(double x, double y, double z)
 
 void LivingEntity::findStandUpPosition(shared_ptr<Entity> vehicle)
 {
-	AABB *boundingBox;
-	double fallbackX = vehicle->x;
-	double fallbackY = vehicle->bb->y0 + vehicle->bbHeight;
-	double fallbackZ = vehicle->z;
+    const double vehicleX = vehicle->x;
+    const double vehicleY = vehicle->bb->y0 + vehicle->bbHeight;
+    const double vehicleZ = vehicle->z;
+    double fallbackX = vehicleX;
+    double fallbackY = vehicleY;
+    double fallbackZ = vehicleZ;
+    const double searchY = vehicleY;
 
-	for (double xDiff = -1.5; xDiff < 2; xDiff += 1.5)
-	{
-		for (double zDiff = -1.5; zDiff < 2; zDiff += 1.5)
-		{
-			if (xDiff == 0 && zDiff == 0)
-			{
-				continue;
-			}
+    for (double xDiff = -1.5; xDiff < 2; xDiff += 1.5)
+    {
+        for (double zDiff = -1.5; zDiff < 2; zDiff += 1.5)
+        {
+            if (xDiff == 0 && zDiff == 0)
+            {
+                continue;
+            }
 
-			int xToInt = (int) (x + xDiff);
-			int zToInt = (int) (z + zDiff);
-			boundingBox = bb->cloneMove(xDiff, 1, zDiff);
+            const int xToInt = static_cast<int>(vehicleX + xDiff);
+            const int zToInt = static_cast<int>(vehicleZ + zDiff);
+            AABB *boundingBox = bb->cloneMove(vehicleX + xDiff - x, searchY + 1 - y, vehicleZ + zDiff - z);
 
-			if (level->getTileCubes(boundingBox, true)->empty())
-			{
-				if (level->isTopSolidBlocking(xToInt, (int) y, zToInt))
-				{
-					teleportTo(x + xDiff, y + 1, z + zDiff);
-					return;
-				}
-				else if (level->isTopSolidBlocking(xToInt, (int) y - 1, zToInt) || level->getMaterial(xToInt, (int) y - 1, zToInt) == Material::water)
-				{
-					fallbackX = x + xDiff;
-					fallbackY = y + 1;
-					fallbackZ = z + zDiff;
-				}
-			}
-		}
-	}
+            if (level->getTileCubes(boundingBox, true)->empty())
+            {
+                if (level->isTopSolidBlocking(xToInt, static_cast<int>(searchY), zToInt))
+                {
+                    teleportTo(vehicleX + xDiff, searchY + 1, vehicleZ + zDiff);
+                    return;
+                }
+                if (level->isTopSolidBlocking(xToInt, static_cast<int>(searchY) - 1, zToInt) ||
+                    level->getMaterial(xToInt, static_cast<int>(searchY) - 1, zToInt) == Material::water)
+                {
+                    fallbackX = vehicleX + xDiff;
+                    fallbackY = searchY + 1;
+                    fallbackZ = vehicleZ + zDiff;
+                }
+            }
+        }
+    }
 
-	teleportTo(fallbackX, fallbackY, fallbackZ);
+    teleportTo(fallbackX, fallbackY, fallbackZ);
 }
 
 bool LivingEntity::shouldShowName()


### PR DESCRIPTION
## Description
Fixes a bug where entering a boat causes it to sink into the ground.

## Changes

### Previous Behavior
Boats on land applied downward motion and ended up visually underground, while collision was above.

### Root Cause
The buoyancy check treated "not full in water" as "should sink", adding downward velocity even on solid ground. The dismount logic also used incorrect position offsets, causing, in some, the player to teleport a few blocks away.

### New Behavior
Boats stay at the correct height on land and ice, and dismounting places the player in a valid nearby spot.

### Fix Implementation
- Replaced the hardcoded ride height formula with `heightOffset`.
- Changed buoyancy checks to only bob when actually in water.
- Removed downward velocity on land.
- Reworked `findStandUpPosition` to use the boar's coordinates consistently and computer bounding box offsets.

### AI Use Disclosure
AI was used to help review the committed code for memory leaks or other issues that may arise. All code was written by me though.

## Related Issues
- Fixes #266 
- Related to #349 
