### PR TITLE
fix: properly detect host environment when copying assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ target_link_libraries(MinecraftClient PRIVATE
   >
 )
 
-if(WIN32)
+if(CMAKE_HOST_WIN32)
   message(STATUS "Starting redist copy...")
   execute_process(
     COMMAND robocopy.exe
@@ -118,7 +118,7 @@ if(WIN32)
             /S /MT /R:0 /W:0 /NP
             /XF "*.h" "*.xml" "*.lang" "*.bat"
   )
-elseif(UNIX)
+elseif(CMAKE_HOST_UNIX)
   message(STATUS "Starting redist copy...")
   execute_process(
     COMMAND rsync -av "${CMAKE_CURRENT_SOURCE_DIR}/x64/Release/" "${CMAKE_CURRENT_BINARY_DIR}/"


### PR DESCRIPTION
## Description
https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_UNIX.html
https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_WIN32.html
https://cmake.org/cmake/help/latest/variable/WIN32.html
https://cmake.org/cmake/help/latest/variable/UNIX.html

This commit fixes compile-time host platform detection when deciding what binary to use for copying assets (rsync or robocopy.exe).

## Changes
WIN32 -> CMAKE_HOST_WIN32
UNIX -> CMAKE_HOST_UNIX

### Previous Behavior
The previous code incorrectly detected the host platform, instead using the target platform. This would result in assets not getting copied over properly if not compiling on Windows, because it would always use robocopy.exe.

### Root Cause
Someone probably accidentally used the wrong variables :)

### New Behavior
The new code correctly detects the host platform at compile-time, resulting in assets getting copied over properly when (cross-)compiling on e.g. Linux.

### AI Use Disclosure
AI was used to generate references (URLs) to the appropriate CMake documentation.