### PR TITLE
Close the villager trade gui when he dies

### DIFF
--- a/Minecraft.World/Villager.cpp
+++ b/Minecraft.World/Villager.cpp
@@ -16,6 +16,7 @@
 #include "net.minecraft.world.level.h"
 #include "..\Minecraft.Client\Textures.h"
 #include "Villager.h"
+#include "AbstractContainerMenu.h"
 
 unordered_map<int, pair<int,int> > Villager::MIN_MAX_VALUES;
 unordered_map<int, pair<int,int> > Villager::MIN_MAX_PRICES;
@@ -306,6 +307,18 @@ void Villager::die(DamageSource *source)
 			}
 		}
 	}
+
+	// Make the gui close if the villager die while trading
+    if (auto currentTrader = tradingPlayer.lock())
+    {
+        if (currentTrader->containerMenu != nullptr)
+        {
+            auto menu = currentTrader->containerMenu;
+            menu->removed(currentTrader);
+        }
+
+        tradingPlayer.reset();
+    }
 
 	AgableMob::die(source);
 }


### PR DESCRIPTION
## Description
Close the villager trading gui when he dies.

## Changes
Adding a logic that close the trading gui when the villager you are interacting with dies.

### Previous Behavior
Previously the gui would not close.

### Root Cause
No logic were found about closing gui when the villager would die.

### New Behavior
When the villager die. We now check if he was interacting with a player, if it does when we close the gui:
https://github.com/user-attachments/assets/b7020d17-b4cf-4c3f-a7a1-5637015e1449

### Fix Implementation
At the end of `void Villager::die` we try to see if a player is trading with the dying villager if it does then we close the gui and reset tradingPlayer.

### AI Use Disclosure
Ai tips changed `std::shared_ptr<Player> currentTrader = tradingPlayer.lock();` to `if (auto currentTrader = tradingPlayer.lock())`.

## Related Issues
- Fixes #623