### PR TITLE
Fix creative mode double block break on single click

### DIFF
--- a/Minecraft.Client/MultiPlayerGameMode.cpp
+++ b/Minecraft.Client/MultiPlayerGameMode.cpp
@@ -133,6 +133,9 @@ void MultiPlayerGameMode::startDestroyBlock(int x, int y, int z, int face)
 
 	if (localPlayerMode->isCreative())
 	{
+		// Skip if we just broke a block — prevents double-break on single clicks
+		if (destroyDelay > 0) return;
+
 		connection->send(shared_ptr<PlayerActionPacket>( new PlayerActionPacket(PlayerActionPacket::START_DESTROY_BLOCK, x, y, z, face) ));
 		creativeDestroyBlock(minecraft, this, x, y, z, face);
 		destroyDelay = 5;
@@ -178,6 +181,7 @@ void MultiPlayerGameMode::stopDestroyBlock()
 
 	isDestroying = false;
 	destroyProgress = 0;
+	destroyDelay = 0;
 	minecraft->level->destroyTileProgress(minecraft->player->entityId, xDestroyBlock, yDestroyBlock, zDestroyBlock, -1);
 }
 


### PR DESCRIPTION
## Description
Fixes the double block break in Creative mode when single-clicking with keyboard & mouse. A single left click would frequently destroy two blocks - the targeted one and the one behind it.

## Changes

### Previous Behavior
In Creative mode, single-clicking to break a block would often destroy two blocks at once. This happened roughly 4-6 out of 10 clicks. Holding the attack button worked fine; only single clicks were affected.

### Root Cause
`MultiPlayerGameMode::startDestroyBlock()` in the creative path never checked `destroyDelay` before destroying a block - it always broke immediately and then set the cooldown. Meanwhile `continueDestroyBlock()` already had this guard (`if (destroyDelay > 0) return`). When `startDestroyBlock` was called on two consecutive game ticks (~50ms apart), both calls went through and broke a block each.

### New Behavior
- Single click: breaks exactly one block
- Hold to break: works as before, breaking blocks at the regular interval
- Rapid clicking: each click registers immediately

### Fix Implementation
Two small changes in `MultiPlayerGameMode.cpp`:

1. **`startDestroyBlock()`** - Added `if (destroyDelay > 0) return;` at the start of the creative path, matching the existing guard that `continueDestroyBlock()` already has. This prevents a second break from firing within the cooldown window.

2. **`stopDestroyBlock()`** - Added `destroyDelay = 0;` so that releasing the mouse button resets the cooldown, keeping rapid clicking responsive.

## Related Issues
- Fixes #566