### PR TITLE
Fix boat gravity

### DIFF
--- a/Minecraft.World/Boat.cpp
+++ b/Minecraft.World/Boat.cpp
@@ -74,7 +74,7 @@ bool Boat::isPushable()
 Boat::Boat(Level *level, double x, double y, double z) : Entity( level )
 {
 	_init();
-	setPos(x, y + heightOffset, z);
+	setPos(x, y + heightOffset + 0.1, z);
 
 	xd = 0;
 	yd = 0;
@@ -209,30 +209,9 @@ void Boat::tick()
 	}
 
 	double lastSpeed = sqrt(xd * xd + zd * zd);
-	if (lastSpeed > MAX_COLLISION_SPEED)
+	if (lastSpeed > MAX_COLLISION_SPEED && waterPercentage > 1)
 	{
-		double xa = cos(yRot * PI / 180);
-		double za = sin(yRot * PI / 180);
-
-		for (int i = 0; i < 1 + lastSpeed * 60; i++)
-		{
-
-			double side = (random->nextFloat() * 2 - 1);
-
-			double side2 = (random->nextInt(2) * 2 - 1) * 0.7;
-			if (random->nextBoolean())
-			{
-				double xx = x - xa * side * 0.8 + za * side2;
-				double zz = z - za * side * 0.8 - xa * side2;
-				level->addParticle(eParticleType_splash, xx, y - 2 / 16.0f, zz, +xd, yd, +zd);
-			}
-			else
-			{
-				double xx = x + xa + za * side * 0.7;
-				double zz = z + za - xa * side * 0.7;
-				level->addParticle(eParticleType_splash, xx, y - 2 / 16.0f, zz, +xd, yd, +zd);
-			}
-		}
+		createSplash(lastSpeed);
 	}
 
 	if (level->isClientSide && doLerp)
@@ -254,7 +233,6 @@ void Boat::tick()
 		}
 		else
 		{
-#if 1
 			// Original
 			//double xt = x + xd;
 			//double yt = y + yd;
@@ -273,51 +251,23 @@ void Boat::tick()
 			xd *= 0.99f;
 			yd *= 0.95f;
 			zd *= 0.99f;
-#else
-			// 4J Stu - Fix for #8280 - Gameplay : Boats behave erratically when exited next to land.
-			// The client shouldn't change the position of the boat
-			double xt = x;// + xd;
-			double yt = y + yd;
-			double zt = z;// + zd;
-			this->setPos(xt, yt, zt);
-
-			// 4J Stu - Fix for #9579 - GAMEPLAY: Boats with a player in them slowly sink under the water over time, and with no player in them they float into the sky.
-			// Just make the boats bob up and down rather than any other client-side movement when not receiving packets from server
-	        if (waterPercentage > 0)
-	        {
-		        double bob = waterPercentage * 2 - 1;
-		        yd += 0.04f * bob;
-	        }
-			else
-			{
-				if (yd < 0) yd /= 2;
-				yd += 0.007f;
-			}
-			//if (onGround)
-			//{
-			xd *= 0.5f;
-			yd *= 0.5f;
-			zd *= 0.5f;
-			//}
-			//xd *= 0.99f;
-			//yd *= 0.95f;
-			//zd *= 0.99f;
-#endif
 		}
 		return;
 	}
 
+	// Bob on water
 	if (waterPercentage > 0)
 	{
 		double bob = waterPercentage * 2 - 1;
 		yd += 0.04f * bob;
 	}
-	else
-	{
-		yd = 0;
+	
+	// Reimplement "gravity"
+	if (level->getTile(x, Mth::floor(y - 0.15), z) == 0 && !onGround) {
+		yd += 0.04f * -1.0; // -1.0 is what bob should return in this situation, just hardcoded.
 	}
 
-
+	// Rider Controls
 	if ( rider.lock() != NULL && rider.lock()->instanceof(eTYPE_LIVINGENTITY) )
 	{
 		shared_ptr<LivingEntity> livingRider = dynamic_pointer_cast<LivingEntity>(rider.lock());
@@ -334,6 +284,7 @@ void Boat::tick()
 
 	double curSpeed = sqrt(xd * xd + zd * zd);
 
+	// Speed Clamp
 	if (curSpeed > MAX_SPEED)
 	{
 		double ratio = MAX_SPEED / curSpeed;
@@ -354,14 +305,15 @@ void Boat::tick()
 		if (acceleration < MIN_ACCELERATION) acceleration = MIN_ACCELERATION;
 	}
 
+	// Slow speed on ground
 	if (onGround)
 	{
 		xd *= 0.5f;
-		yd *= 0.5f;
 		zd *= 0.5f;
 	}
 	move(xd, yd, zd);
 
+	// Break boat 
 	if ((horizontalCollision && lastSpeed > 0.20))
 	{
 		if (!level->isClientSide && !removed)
@@ -401,6 +353,7 @@ void Boat::tick()
 	yRot += (float) rotDiff;
 	setRot(yRot, xRot);
 
+	// Server only code below
 	if(level->isClientSide) return;
 
 	vector<shared_ptr<Entity> > *entities = level->getEntities(shared_from_this(), bb->grow(0.2f, 0, 0.2f));
@@ -444,13 +397,37 @@ void Boat::tick()
 	}
 }
 
+void Boat::createSplash(double particleStrengh) {
+	double xa = cos(yRot * PI / 180);
+	double za = sin(yRot * PI / 180);
+
+	for (int i = 0; i < 1 + particleStrengh * 60; i++)
+	{
+		double side = (random->nextFloat() * 2 - 1);
+
+		double side2 = (random->nextInt(2) * 2 - 1) * 0.7;
+		if (random->nextBoolean())
+		{
+			double xx = x - xa * side * 0.8 + za * side2;
+			double zz = z - za * side * 0.8 - xa * side2;
+			level->addParticle(eParticleType_splash, xx, y - 2 / 16.0f, zz, +xd, yd, +zd);
+		}
+		else
+		{
+			double xx = x + xa + za * side * 0.7;
+			double zz = z + za - xa * side * 0.7;
+			level->addParticle(eParticleType_splash, xx, y - 2 / 16.0f, zz, +xd, yd, +zd);
+		}
+	}
+}
+
 void Boat::positionRider()
 {
 	if (rider.lock() == NULL) return;
 
 	double xa = cos(yRot * PI / 180) * 0.4;
 	double za = sin(yRot * PI / 180) * 0.4;
-	rider.lock()->setPos(x + xa, y + getRideHeight() + rider.lock()->getRidingHeight(), z + za);
+	rider.lock()->setPos(x + xa, y + getRideHeight() + rider.lock()->getRidingHeight()-0.5, z + za);
 }
 
 

--- a/Minecraft.World/Boat.h
+++ b/Minecraft.World/Boat.h
@@ -60,6 +60,7 @@ public:
 	virtual void lerpTo(double x, double y, double z, float yRot, float xRot, int steps);
 	virtual void lerpMotion(double xd, double yd, double zd);
 	virtual void tick();
+	void createSplash(double particleStrengh);
 	virtual void positionRider();
 
 protected:


### PR DESCRIPTION
Image of boat falling... 
<img width="1916" height="1054" alt="image" src="https://github.com/user-attachments/assets/bd774bcb-7672-4290-93fe-953bee4fbcb2" />

## Description & Changes
Fixes #266
Reimplements removed gravity from #615 (#615 unintentionally removes boat gravity)
Removes unreachable code
Comments code
Fixes splash particles rendering anywhere, instead of just in water.

### Previous Behavior
Boats did not have gravity
Boats would fall through land on a passenger being added
Boats would render splash particles when going fast enough, even when not in water.

### Root Cause
#615 improves boat bobbing which also handled gravity.
Boats were intersected with the ground, causing them to fall through the ground
Splash particles did not check for water, just high velocity.

### New Behavior
Boats now have gravity
Boats no longer phase through blocks on ride. 
Splash particles render in water.

## Related Issues
- Fixes #266 
- Related to #615 
