### PR TITLE
Add a launch argument for full screen

### DIFF
--- a/Minecraft.Client/PlayerConnection.cpp
+++ b/Minecraft.Client/PlayerConnection.cpp
@@ -1093,6 +1093,10 @@ void PlayerConnection::handleContainerClose(shared_ptr<ContainerClosePacket> pac
 #ifndef _CONTENT_PACKAGE
 void PlayerConnection::handleContainerSetSlot(shared_ptr<ContainerSetSlotPacket> packet)
 {
+	if(player->gameMode->isSurvival()){ // Still allow creative players to change slots manually with packets(?) -- might want this different.
+		server->warn(L"Player " + player->getName() + L" just tried to set a slot in a container in survival mode");
+		return;
+	}
 	if (packet->containerId == AbstractContainerMenu::CONTAINER_ID_CARRIED )
 	{
 		player->inventory->setCarried(packet->item);
@@ -1589,6 +1593,10 @@ void PlayerConnection::handleCraftItem(shared_ptr<CraftItemPacket> packet)
 	Recipy::INGREDIENTS_REQUIRED *pRecipeIngredientsRequired=Recipes::getInstance()->getRecipeIngredientsArray();
 	shared_ptr<ItemInstance> pTempItemInst=pRecipeIngredientsRequired[iRecipe].pRecipy->assemble(nullptr);
 
+	size_t recipeCount = Recipes::getInstance()->getRecipies()->size();
+	if (iRecipe < 0 || iRecipe >= (int)recipeCount)
+		return;
+
 	if(app.DebugSettingsOn() && (player->GetDebugOptions()&(1L<<eDebugSetting_CraftAnything)))
 	{
 		pTempItemInst->onCraftedBy(player->level, dynamic_pointer_cast<Player>( player->shared_from_this() ), pTempItemInst->count );
@@ -1607,9 +1615,21 @@ void PlayerConnection::handleCraftItem(shared_ptr<CraftItemPacket> packet)
 	{
 
 
-		// TODO 4J Stu - Assume at the moment that the client can work this out for us...
-		//if(pRecipeIngredientsRequired[iRecipe].bCanMake)
-		//{
+		Recipy::INGREDIENTS_REQUIRED &req = pRecipeIngredientsRequired[iRecipe];
+		if (req.iType == RECIPE_TYPE_3x3 && dynamic_cast<CraftingMenu *>(player->containerMenu) == NULL)
+		{
+			server->warn(L"Player " + player->getName() + L" tried to craft a 3x3 recipe without a crafting bench");
+			return;
+		}
+		for (int i = 0; i < req.iIngC; i++){
+			int need = req.iIngValA[i];
+			int have = player->inventory->countResource(req.iIngIDA[i], req.iIngAuxValA[i]);
+			if (have < need){
+				server->warn(L"Player " + player->getName() + L" just tried to craft item " + to_wstring(pTempItemInst->id) + L" with insufficient ingredients");
+				return;
+			}
+		}
+
 		pTempItemInst->onCraftedBy(player->level, dynamic_pointer_cast<Player>( player->shared_from_this() ), pTempItemInst->count );
 
 		// and remove those resources from your inventory

--- a/Minecraft.World/Inventory.cpp
+++ b/Minecraft.World/Inventory.cpp
@@ -343,6 +343,18 @@ bool Inventory::hasResource(int type)
 	return true;
 }
 
+int Inventory::countResource(int type, int auxVal)
+{
+	int count = 0;
+	for (unsigned int i = 0; i < items.length; i++)
+	{
+		if (items[i] != NULL && items[i]->id == type &&
+		    (auxVal == -1 || items[i]->getAuxValue() == auxVal))
+			count += items[i]->count;
+	}
+	return count;
+}
+
 void Inventory::swapSlots(int from, int to)
 {
 	shared_ptr<ItemInstance> tmp = items[to];

--- a/Minecraft.World/Inventory.h
+++ b/Minecraft.World/Inventory.h
@@ -68,6 +68,7 @@ public:
 	shared_ptr<ItemInstance> getResourceItem(int type,int iAuxVal);
 
 	bool hasResource(int type);
+	int countResource(int type, int auxVal);
 	void swapSlots(int from, int to);
 	bool add(shared_ptr<ItemInstance> item);
 	shared_ptr<ItemInstance> removeItem(unsigned int slot, int count);


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
<!-- Briefly describe the changes this PR introduces. -->
This PR adds a feature described in #633 that makes `-fullscreen` launch the game in full screen mode. Addendum: had to add `*.user` to the .gitignore as it was trying to commit my per-user configurations (like launch options for debug).

## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->
No `-fullscreen` launch argument was present.

### New Behavior
<!-- Describe how the code behaves after this change. -->
Upon running `Minecraft.Client.exe -fullscreen`, the game launches full screen without borders.

### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->
-  Added a option called `fullscreen` to the options struct.
- Parsed the fullscreen option.
- Used the `launchOptions.fullscreen` flag to decide if fullscreen should be toggled in main.

### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->
No AI or LLMs were used. Code was completely written by me.

## Related Issues
- Fixes #633
- Related to #633
