### PR TITLE
Fix sound settings not applying

### DIFF
--- a/Minecraft.Client/Common/Audio/SoundEngine.cpp
+++ b/Minecraft.Client/Common/Audio/SoundEngine.cpp
@@ -652,7 +652,6 @@ void SoundEngine::playUI(int iSound, float volume, float pitch)
     float finalVolume = volume * m_MasterEffectsVolume;
     if (finalVolume > 1.0f)
         finalVolume = 1.0f;
-	printf("UI Sound volume set to %f\nEffects volume: %f\n", finalVolume, m_MasterEffectsVolume);
 
     ma_sound_set_volume(&s->sound, finalVolume);
     ma_sound_set_pitch(&s->sound, pitch);


### PR DESCRIPTION
## Description
Fixes issues with volume settings not applying and causing artifacting

## Changes

### Previous Behavior
it would not set the volume settings

### Root Cause
yeah so i was stupid and made it force to vol 1 on accident for sounds, and just never update the music vol except on reload

### New Behavior
it works !!

### Fix Implementation
yeah i just 

### AI Use Disclosure
no