### PR TITLE
Allow closing the game with ALT F4

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -587,7 +587,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		else if (vk == VK_MENU)
 			vk = (lParam & (1 << 24)) ? VK_RMENU : VK_LMENU;
 		g_KBMInput.OnKeyDown(vk);
-		break;
+		return DefWindowProc(hWnd, message, wParam, lParam);
 	}
 	case WM_KEYUP:
 	case WM_SYSKEYUP:


### PR DESCRIPTION
## Description
Allows closing the game with ALT F4 by passing the KEYDOWN messages to DefWindowProc instead of returning 0

## Changes

### Previous Behavior
Pressing ALT F4 does nothing

### Root Cause
KEYDOWN messages were being consumed, blocking Windows from handling the ALT F4 shortcut

### New Behavior
Pressing ALT F4 will now close the game

### Fix Implementation
Instead of breaking in the KEYDOWN switch case and returning 0, the message is passed to DefWindowProc, letting Windows handle it, making ALT F4 work properly 