### PR TITLE
fix gamma breaking f3 menu

### DIFF
--- a/Minecraft.Client/GameRenderer.cpp
+++ b/Minecraft.Client/GameRenderer.cpp
@@ -1169,8 +1169,6 @@ void GameRenderer::render(float a, bool bFirst)
 
 		lastNsTime = System::nanoTime();
 
-		ApplyGammaPostProcess();
-
 		if (!mc->options->hideGui || mc->screen != NULL)
 		{
 			mc->gui->render(a, mc->screen != NULL, xMouse, yMouse);
@@ -1196,6 +1194,7 @@ void GameRenderer::render(float a, bool bFirst)
 		if (mc->screen != NULL && mc->screen->particles != NULL) mc->screen->particles->render(a);
 	}
 
+	ApplyGammaPostProcess();
 }
 
 void GameRenderer::renderLevel(float a)


### PR DESCRIPTION
## Description
F3 menu becomes invisible when changing gamma value

## Changes

### Previous Behavior
F3 menu becomes invisible when changing gamma value

### Root Cause
ApplyGammaPostProcess() was called before the gui causing the f3 menu to not draw

### New Behavior
f3 menu now renderes correctly no matter the gamma

### Fix Implementation
Run ApplyGammaPostProcess() after the GUI

### AI Use Disclosure
None

## Related Issues
- Fixes #689 
