### PR TITLE
[Bug Fix] Controller: Creative Menu scroll broken: caused by pageStep variable to use 5 instead of 1.

### DIFF
--- a/Minecraft.Client/Common/UI/IUIScene_CreativeMenu.cpp
+++ b/Minecraft.Client/Common/UI/IUIScene_CreativeMenu.cpp
@@ -1099,42 +1099,42 @@ void IUIScene_CreativeMenu::handleAdditionalKeyPress(int iAction)
 		break;
 	case ACTION_MENU_OTHER_STICK_DOWN:
 		{
-			int pageStep = TabSpec::rows;
+			int pageStep = 1; // override: use 1 so thumbstick increment/decrement behaves alike the mouse wheel implementation.
 #ifdef _WINDOWS64
-			if (g_KBMInput.WasMouseWheelConsumed())
-			{
-				pageStep = 1;
-			}
+            if (g_KBMInput.WasMouseWheelConsumed())
+            {
+                pageStep = 1;
+            }
 #endif
-			m_tabPage[m_curTab] += pageStep;
-			if(m_tabPage[m_curTab] >= specs[m_curTab]->getPageCount())
-			{
-				m_tabPage[m_curTab] = specs[m_curTab]->getPageCount() - 1;
-			}
-			else
-			{
-				switchTab(m_curTab);
-			}
+            m_tabPage[m_curTab] += pageStep;
+            if(m_tabPage[m_curTab] >= specs[m_curTab]->getPageCount())
+            {
+                m_tabPage[m_curTab] = specs[m_curTab]->getPageCount() - 1;
+            }
+            else
+            {
+                switchTab(m_curTab);
+            }
 		}
 		break;
 	case ACTION_MENU_OTHER_STICK_UP:
 		{
-			int pageStep = TabSpec::rows;
+			int pageStep = 1; // override: use 1 so thumbstick increment/decrement behaves alike the mouse wheel implementation.
 #ifdef _WINDOWS64
-			if (g_KBMInput.WasMouseWheelConsumed())
-			{
-				pageStep = 1;
-			}
+            if (g_KBMInput.WasMouseWheelConsumed())
+            {
+                pageStep = 1;
+            }
 #endif
-			m_tabPage[m_curTab] -= pageStep;
-			if(m_tabPage[m_curTab] < 0)
-			{
-				m_tabPage[m_curTab] = 0;
-			}
-			else
-			{
-				switchTab(m_curTab);
-			}
+            m_tabPage[m_curTab] -= pageStep;
+            if(m_tabPage[m_curTab] < 0)
+            {
+                m_tabPage[m_curTab] = 0;
+            }
+            else
+            {
+                switchTab(m_curTab);
+            }
 		}
 		break;
 	}


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
<!-- Briefly describe the changes this PR introduces. -->
This proposed change removes the `TabSpec::rows` used in the math residing in `IUIScene_CreativeMenu.cpp` lines 1102 and 1122 which is broken for controllers.


## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->

[Current behaviour.webm](https://github.com/user-attachments/assets/ba216c5e-f373-4f31-876a-41f6cfe83d93)


### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->
It looks like 4J used the `TabSpec::rows` (value: 5) reference for the old way the Creative Menu was handled before the merge of '**[PR] Implement smooth scrolling in Creative Mode menu #240**'; it did not take into consideration regarding Controller inputs.

When `void IUIScene_CreativeMenu::handleAdditionalKeyPress(int iAction)` is triggered, it uses a switch case to handle the inputs, and upon `case ACTION_MENU_OTHER_STICK_DOWN:` or `case ACTION_MENU_OTHER_STICK_UP:` it assigns `int pageStep = TabSpec::rows` which has a hardcoded value of 5.

This will work fine for PC Controls due to the if statement present underneath `if (g_KBMInput.WasMouseWheelConsumed()) {    pageStep = 1; ...`   however there's no check for the controller, so I propose we set a hardcoded `1` instead, and for future additions, we can add more if statements if other forms of inputs make its way into the repo :3



### New Behavior
<!-- Describe how the code behaves after this change. -->
The menu scrolls "smoothly" (ignore the breakpoint debug pausing)
[Proposed Change.webm](https://github.com/user-attachments/assets/88022b8e-aa57-4742-a932-b20ae08a6a69)


### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->
<img width="966" height="42" alt="image" src="https://github.com/user-attachments/assets/fb923ddb-6c43-4f28-85d6-05349af8a668" />
Snippet:
<img width="1836" height="1014" alt="image" src="https://github.com/user-attachments/assets/1534709f-0f1d-4ad2-9af8-1f70c4c77c7c" />


### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->

## Related Issues
- Fixes 'Cant scroll Creative Mode Inventory with controller #454 '
