### PR TITLE
Fix UI button staying focused on mouse out + controller snap

### DIFF
--- a/Minecraft.Client/Common/UI/UIController.cpp
+++ b/Minecraft.Client/Common/UI/UIController.cpp
@@ -865,6 +865,7 @@ void UIController::tickInput()
 							int hitControlId = -1;
 							S32 hitArea = INT_MAX;
 							UIControl *hitCtrl = NULL;
+							bool hitAny = false;
 							for (size_t i = 0; i < controls->size(); ++i)
 							{
 								UIControl *ctrl = (*controls)[i];
@@ -906,7 +907,8 @@ void UIController::tickInput()
 										hitControlId = -1;
 										hitArea = INT_MAX;
 										hitCtrl = NULL;
-										break; // ButtonList takes priority
+										hitAny = true;
+									break; // ButtonList takes priority
 									}
 									if (type == UIControl::eTexturePackList)
 									{
@@ -919,6 +921,7 @@ void UIController::tickInput()
 										hitControlId = -1;
 										hitArea = INT_MAX;
 										hitCtrl = NULL;
+										hitAny = true;
 										break;
 									}
 									S32 area = cw * ch;
@@ -927,6 +930,7 @@ void UIController::tickInput()
 										hitControlId = ctrl->getId();
 										hitArea = area;
 										hitCtrl = ctrl;
+										hitAny = true;
 										if (type == UIControl::eSlider)
 											m_bMouseHoverHorizontalList = true;
 									}
@@ -952,6 +956,19 @@ void UIController::tickInput()
 									{
 										((UIControl_TextInput *)hitCtrl)->setCaretVisible(false);
 									}
+								}
+							}
+							else if (!hitAny && !pScene->isDirectEditBlocking())
+							{
+								// Mouse moved away from all controls — clear focus if set
+								Iggy *movie = pScene->getMovie();
+								IggyFocusHandle currentFocus = IGGY_FOCUS_NULL;
+								IggyFocusableObject focusables[64];
+								S32 numFocusables = 0;
+								IggyPlayerGetFocusableObjects(movie, &currentFocus, focusables, 64, &numFocusables);
+								if (currentFocus != IGGY_FOCUS_NULL)
+								{
+									IggyPlayerSetFocusRS(movie, IGGY_FOCUS_NULL, 0);
 								}
 							}
 						}


### PR DESCRIPTION
## Description
Fix buttons staying selected after the mouse moves away and added controller snap when no button is focused.

### Previous Behavior
When moving the mouse off all buttons, the last hovered button remained selected.

### Root Cause
When the mouse hovered a button, UIController::tickInput() would set focus but didn’t remove that focus when the mouse moved away. The button therefore stayed focused on the last button the mouse was hovered on, and the code that should auto select the first control when focus is empty never ran.

### New Behavior
Moving the mouse off all buttons now clears the visual selection. When a controller directional input is used with no button focused then it focuses to the first available button without consuming the input press.

### Fix Implementation
Added a hitAny check in UIController::tickInput() to clear Iggy focus when the mouse leaves all controls. This avoids SetFocusToElement(-1) snapping to element 0 and allows the existing Windows snap to first logic in sendInputToMovie() to handle controller focus correctly.

### AI Use Disclosure
None