### PR TITLE
50% - 100% increase to some mob caps.

### DIFF
--- a/Minecraft.World/MobCategory.h
+++ b/Minecraft.World/MobCategory.h
@@ -7,9 +7,9 @@ class MobCategory
 {
 public:
 	// 4J - putting constants for xbox spawning in one place to tidy things up a bit - all numbers are per level
-	static const int CONSOLE_MONSTERS_HARD_LIMIT = 75; //50									// Max number of enemies (skeleton, zombie, creeper etc) that the mob spawner will produce
-	static const int CONSOLE_ANIMALS_HARD_LIMIT = 75;  //50									// Max number of animals (cows, sheep, pigs) that the mob spawner will produce	
-	static const int CONSOLE_AMBIENT_HARD_LIMIT = 30;  //20								// Ambient mobs
+	static const int CONSOLE_MONSTERS_HARD_LIMIT = 70; //50									// Max number of enemies (skeleton, zombie, creeper etc) that the mob spawner will produce
+	static const int CONSOLE_ANIMALS_HARD_LIMIT = 70;  //50									// Max number of animals (cows, sheep, pigs) that the mob spawner will produce	
+	static const int CONSOLE_AMBIENT_HARD_LIMIT = 20;  //20								// Ambient mobs
 
 	static const int MAX_XBOX_CHICKENS = 16; //8										// Max number of chickens that the mob spawner will produce
 	static const int MAX_XBOX_WOLVES = 16; //8										// Max number of wolves that the mob spawner will produce


### PR DESCRIPTION
## Description
This PR slightly increases the natural spawn cap on mob spawns. 


## Changes
- Monsters from 50 to 70
- Animals from 50 to 70
- Chickens from 8 to 16
- Wolves from 8 to 16
- Mooshrooms from 2 to 8
- Squid from 5 to 10
- Villagers + Breeding from 35 to 50

### Previous Behavior
Mob Spawning was kinda limited so some mobs were kinda hard to find when they shouldn't be necessarily.

### Root Cause
MobCategory.h set the hard limits.

### New Behavior
Now the natural limit can be increased due to newer hardware and having access to.

### Fix Implementation
Increased the hard limits that are established in MobCategory.h

### AI Use Disclosure
No AI.

## Related Issues
- Related to #447 
