### PR TITLE
Fix FOV being applied twice from redundant fov->settings application.

### DIFF
--- a/Minecraft.Client/Common/Consoles_App.cpp
+++ b/Minecraft.Client/Common/Consoles_App.cpp
@@ -1407,7 +1407,7 @@ void CMinecraftApp::ActionGameSettings(int iPad,eGameSetting eVal)
 		if(iPad==ProfileManager.GetPrimaryPad())
 		{
 			float fovDeg = 70.0f + (float)GameSettingsA[iPad]->ucFov * 40.0f / 100.0f;
-			pMinecraft->gameRenderer->SetFovVal(fovDeg);
+            pMinecraft->gameRenderer->SetFovVal(iPad, fovDeg);
 		}
 		break;
 	case eGameSetting_Difficulty:		

--- a/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
@@ -279,7 +279,7 @@ void UIScene_DebugOverlay::handleSliderMove(F64 sliderId, F64 currentValue)
 			if (v < 0) v = 0;
 			if (v > 100) v = 100;
 			int fovDeg = 70 + v * 40 / 100;
-			pMinecraft->gameRenderer->SetFovVal((float)fovDeg);
+            pMinecraft->gameRenderer->SetFovVal(m_iPad, (float)fovDeg);
 			app.SetGameSettings(m_iPad, eGameSetting_FOV, v);
 
 			WCHAR TempString[256];

--- a/Minecraft.Client/Common/UI/UIScene_SettingsGraphicsMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_SettingsGraphicsMenu.cpp
@@ -219,7 +219,7 @@ void UIScene_SettingsGraphicsMenu::handleSliderMove(F64 sliderId, F64 currentVal
 			m_sliderFOV.handleSliderMove(value);
 			Minecraft* pMinecraft = Minecraft::GetInstance();
 			int fovValue = sliderValueToFov(value);
-			pMinecraft->gameRenderer->SetFovVal((float)fovValue);
+            pMinecraft->gameRenderer->SetFovVal(m_iPad, (float)fovValue);
 			app.SetGameSettings(m_iPad, eGameSetting_FOV, value);
 			WCHAR TempString[256];
 			swprintf((WCHAR*)TempString, 256, L"FOV: %d", fovValue);

--- a/Minecraft.Client/Common/XUI/XUI_DebugOverlay.cpp
+++ b/Minecraft.Client/Common/XUI/XUI_DebugOverlay.cpp
@@ -102,7 +102,7 @@ HRESULT CScene_DebugOverlay::OnInit( XUIMessageInit *pInitData, BOOL &bHandled )
 
 	Minecraft *pMinecraft = Minecraft::GetInstance();
 	m_setTime.SetValue( pMinecraft->level->getLevelData()->getTime() % 24000 );
-	m_setFov.SetValue( (int)pMinecraft->gameRenderer->GetFovVal());
+    m_setFov.SetValue((int)pMinecraft->gameRenderer->GetFovVal(ProfileManager.GetPrimaryPad()));
 
 	XuiSetTimer(m_hObj,0,DEBUG_OVERLAY_UPDATE_TIME_PERIOD);
 
@@ -266,20 +266,26 @@ HRESULT CScene_DebugOverlay::OnNotifyValueChanged( HXUIOBJ hObjSource, XUINotify
 	if( hObjSource == m_setFov )
 	{
 		Minecraft *pMinecraft = Minecraft::GetInstance();
-		pMinecraft->gameRenderer->SetFovVal((float)pNotifyValueChangedData->nValue);
+        pMinecraft->gameRenderer->SetFovVal(pNotifyValueChangedData->UserIndex, (float)pNotifyValueChangedData->nValue);
 	}
 	return S_OK;
 }
 
-HRESULT CScene_DebugOverlay::OnTimer( XUIMessageTimer *pTimer, BOOL& bHandled )
+HRESULT CScene_DebugOverlay::OnTimer(XUIMessageTimer *pTimer, BOOL &bHandled)
 {
-	Minecraft *pMinecraft = Minecraft::GetInstance();
-	if(pMinecraft->level != NULL)
-	{
-		m_setTime.SetValue( pMinecraft->level->getLevelData()->getTime() % 24000 );
-		m_setFov.SetValue( (int)pMinecraft->gameRenderer->GetFovVal());
-	}
-	return S_OK;
+    Minecraft *pMinecraft = Minecraft::GetInstance();
+    if(pMinecraft->level != NULL)
+    {
+        m_setTime.SetValue(pMinecraft->level->getLevelData()->getTime() % 24000);
+        for (int i = 0; i < XUSER_MAX_COUNT; i++)
+        {
+            if (pMinecraft->localplayers[i] != NULL)
+            {
+                m_setFov.SetValue((int)pMinecraft->gameRenderer->GetFovVal(i));
+            }
+        }
+    }
+    return S_OK;
 }
 
 void CScene_DebugOverlay::SetSpawnToPlayerPos()

--- a/Minecraft.Client/GameRenderer.cpp
+++ b/Minecraft.Client/GameRenderer.cpp
@@ -130,12 +130,11 @@ GameRenderer::GameRenderer(Minecraft *mc)
 	darkenWorldAmount = 0.0f;
 	darkenWorldAmountO = 0.0f;
 
-	m_fov=70.0f;
-
 	// 4J Stu - Init these so they are setup before the tick
 	for( int i = 0; i < 4; i++ )
 	{
 		fov[i] = oFov[i] = 1.0f;
+        m_fov[i] = 70.0f;
 	}
 
 	this->mc = mc;
@@ -358,54 +357,51 @@ void GameRenderer::pick(float a)
 	}
 }
 
-void GameRenderer::SetFovVal(float fov)
-{
-	m_fov=fov;
-}
-
-float GameRenderer::GetFovVal()
-{
-	return m_fov;
-}
-
 void GameRenderer::tickFov()
 {
-	shared_ptr<LocalPlayer>player = dynamic_pointer_cast<LocalPlayer>(mc->cameraTargetPlayer);
+    shared_ptr<LocalPlayer> player = dynamic_pointer_cast<LocalPlayer>(mc->cameraTargetPlayer);
+    int playerIdx = player ? player->GetXboxPad() : 0;
+    tFov[playerIdx] = player->getFieldOfViewModifier();
+    oFov[playerIdx] = fov[playerIdx];
+    fov[playerIdx] += (tFov[playerIdx] - fov[playerIdx]) * 0.5f;
+    if (fov[playerIdx] > 1.5f)
+    {
+        fov[playerIdx] = 1.5f;
+    }
+    if (fov[playerIdx] < 0.1f)
+    {
+        fov[playerIdx] = 0.1f;
+    }
+}
 
-	int playerIdx = player ? player->GetXboxPad() : 0;
-	tFov[playerIdx] = player->getFieldOfViewModifier();
+void GameRenderer::SetFovVal(int playerIdx, float fov)
+{
+    m_fov[playerIdx] = fov;
+}
 
-	oFov[playerIdx] = fov[playerIdx];
-	fov[playerIdx] += (tFov[playerIdx] - fov[playerIdx]) * 0.5f;
-
-	if (fov[playerIdx] > 1.5f) fov[playerIdx] = 1.5f;
-	if (fov[playerIdx] < 0.1f) fov[playerIdx] = 0.1f;
+float GameRenderer::GetFovVal(int playerIdx)
+{
+    return m_fov[playerIdx];
 }
 
 float GameRenderer::getFov(float a, bool applyEffects)
 {
-	if (cameraFlip > 0 ) return 90;
-
-	shared_ptr<LocalPlayer> player = dynamic_pointer_cast<LocalPlayer>(mc->cameraTargetPlayer);
-	int playerIdx = player ? player->GetXboxPad() : 0;
-	float fov = m_fov;//70;
-	if (applyEffects)
-	{
-		fov += mc->options->fov * 40;
-		fov *= oFov[playerIdx] + (this->fov[playerIdx] - oFov[playerIdx]) * a;
-	}
-	if (player->getHealth() <= 0)
-	{
-		float duration = player->deathTime + a;
-
-		fov /= ((1 - 500 / (duration + 500)) * 2.0f + 1);
-	}
-
-	int t = Camera::getBlockAt(mc->level, player, a);
-	if (t != 0 && Tile::tiles[t]->material == Material::water) fov = fov * 60 / 70;
-
-	return fov + fovOffsetO + (fovOffset - fovOffsetO) * a;
-
+    if (cameraFlip > 0 ) return 90;
+    shared_ptr<LocalPlayer> player = dynamic_pointer_cast<LocalPlayer>(mc->cameraTargetPlayer);
+    int playerIdx = player ? player->GetXboxPad() : 0;
+    float fov = m_fov[playerIdx];//70;
+    if (applyEffects)
+    {
+        fov *= oFov[playerIdx] + (this->fov[playerIdx] - oFov[playerIdx]) * a;
+    }
+    if (player->getHealth() <= 0)
+    {
+        float duration = player->deathTime + a;
+        fov /= ((1 - 500 / (duration + 500)) * 2.0f + 1);
+    }
+    int t = Camera::getBlockAt(mc->level, player, a);
+    if (t != 0 && Tile::tiles[t]->material == Material::water) fov = fov * 60 / 70;
+    return fov + fovOffsetO + (fovOffset - fovOffsetO) * a;
 }
 
 void GameRenderer::bobHurt(float a)

--- a/Minecraft.Client/GameRenderer.h
+++ b/Minecraft.Client/GameRenderer.h
@@ -87,12 +87,13 @@ private:
 
     bool isInClouds;
 
-	float m_fov;
-public:
+	float m_fov[4];
+
+  public:
 	GameRenderer(Minecraft *mc);
 	~GameRenderer();
-	void SetFovVal(float fov);
-	float GetFovVal();
+    void SetFovVal(int playerIdx, float fov);
+    float GetFovVal(int playerIdx);
 
 public:
 	void tick(bool bFirst);


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Fix FOV being applied twice from redundant fov->settings application. Bump the main field-of-view variables to array's that correspond with the max amount of local players (4).

## Changes

### Previous Behavior
When the FOV would be changed in the settings menu, both m_fov and options->fov would be set, and would be multiplied twice.
(on 110fov)
<img width="2504" height="1385" alt="image" src="https://github.com/user-attachments/assets/c05fdca6-1c8e-4bc3-a67f-56d07e104c9a" />


### Root Cause
m_fov and options->fov were being written to. getFov() reads both, causing field of view to be multiplied.

### New Behavior
Field of view applications works as intended. 
(on 110fov)
<img width="2505" height="1384" alt="image" src="https://github.com/user-attachments/assets/106339c5-0557-4428-84fe-41996823d6c4" />


### Fix Implementation
Refactored field-of-view logic to correctly apply once in single-player and split-screen environments.

### AI Use Disclosure
None.

## Related Issues
- Related to #802
- Fixes #838 
