### PR TITLE
mobs not dropping cooked meat with oneshot fire arrow (does drop with non oneshot arrow)

### DIFF
--- a/Minecraft.World/Arrow.cpp
+++ b/Minecraft.World/Arrow.cpp
@@ -303,16 +303,20 @@ void Arrow::tick()
 				damageSource = DamageSource::arrow(dynamic_pointer_cast<Arrow>(shared_from_this()), owner);
 			}
 
+			if(!res->entity->isInvulnerable())
+			{
+				if (isOnFire() && res->entity->GetType() != eTYPE_ENDERMAN)
+				{
+					res->entity->setOnFire(5);
+				}
+			}
+
 			if(res->entity->hurt(damageSource, dmg))
 			{
 				// Firx for #67839 - Customer Encountered: Bows enchanted with "Flame" still set things on fire if pvp/attack animals is turned off
 				// 4J Stu - We should not set the entity on fire unless we can cause some damage (this doesn't necessarily mean that the arrow hit lowered their health)
 				// set targets on fire first because we want cooked
 				// pork/chicken/steak
-				if (isOnFire() && res->entity->GetType() != eTYPE_ENDERMAN)
-				{
-					res->entity->setOnFire(5);
-				}
 
 				if (res->entity->instanceof(eTYPE_LIVINGENTITY))
 				{


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Mobs now drop their cooked meat if oneshot with arrow.

## Changes
Set on fire before the entity takes damage (with invulnerability check).

### Previous Behavior
Mobs that drop meat that got oneshot with an flame arrow would not drop cooked meat.

### Root Cause
The mob takes damage before being set on fire and thus dieing before fire works.

### New Behavior
The mob is set on fire before taking damage so that the isOnFire() check does not fail.

### Fix Implementation
move the setOnFire() before the hurt is called while still running the invulnerability check (so if pvp is off the player does not get set on fire).

### AI Use Disclosure
No ai was used

## Related Issues
- Fixes #839
