### PR TITLE
bugfix: Holding CTRL key resets flying acceleration

### DIFF
--- a/Minecraft.Client/LocalPlayer.cpp
+++ b/Minecraft.Client/LocalPlayer.cpp
@@ -278,7 +278,7 @@ void LocalPlayer::aiStep()
 	}
 	if (isSneaking()) sprintTriggerTime = 0;
 #ifdef _WINDOWS64
-	if (input->sprinting && onGround && enoughFoodToSprint && !isUsingItem() && !hasEffect(MobEffect::blindness) && !isSneaking())
+	if (input->sprinting && !isSprinting() && onGround && enoughFoodToSprint && !isUsingItem() && !hasEffect(MobEffect::blindness) && !isSneaking())
 	{
 		setSprinting(true);
 	}


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
<!-- Briefly describe the changes this PR introduces. -->
When flying in creative mode, attempting to hold down the <kbd>CTRL</kbd> key causes the player to fly slower rather than faster (like with double tapping <kbd>W</kbd>). This PR fixes that bug such that pressing <kbd>CTRL</kbd> will also make the player fly as fast as double tapping <kbd>W</kbd>

## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->
Holding <kbd>CTRL</kbd> slows the player down when flying. 

### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->
The flying velocity ramp-up behavior is scaled using the following formula: https://github.com/smartcmd/MinecraftConsoles/blob/bbe396d90d6cf292c18017129e4f9f619c406f32/Minecraft.Client/LocalPlayer.cpp#L444 where `SPRINT_DURATION` is a constant that is always 600. When holding <kbd>CTRL</kbd>, `sprintTime` always gets reset to 600. Therefore, `scale = 0` which makes the player slow. Using a combination of tracepoints, I determined that `setSprinting(true)` sets `sprintTime = SPRINT_DURATION`, which means that while pressing <kbd>CTRL</kbd> one time will start the countdown here: https://github.com/smartcmd/MinecraftConsoles/blob/bbe396d90d6cf292c18017129e4f9f619c406f32/Minecraft.Client/LocalPlayer.cpp#L169 holding the key will reset this countdown, meaning `scale` will never go above zero. I have determined that this line: https://github.com/smartcmd/MinecraftConsoles/blob/bbe396d90d6cf292c18017129e4f9f619c406f32/Minecraft.Client/LocalPlayer.cpp#L281 is missing a check to see if the player is already in the sprinting state.

### New Behavior
<!-- Describe how the code behaves after this change. -->
Holding <kbd>CTRL</kbd> now speeds the player up to full velocity when flying. 

### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->
Added a check to make sure that `setSprinting(true)` was not called if the player is already "sprinting" when flying. `setSprinting()` causes the acceleration to start from zero. Therefore, if you hold down <kbd>CTRL</kbd> `setSprinting(true)` will be called repeatedly thus always slowing down the player when flying.

### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->
AI was only used to understand the quadratic acceleration code:
```cpp
// Accelrate up to full speed if we are sprinting, moving in the direction of the view vector 
flyX = (float)viewVector->x * input->ya;
flyY = (float)viewVector->y * input->ya; 
flyZ = (float)viewVector->z * input->ya; 
float scale = ((float)(SPRINT_DURATION - sprintTime))/10.0f; 
scale = scale * scale; 
if ( scale > 1.0f ) scale = 1.0f; 
flyX *= scale; 
flyY *= scale; 
flyZ *= scale;
```

## Related Issues
- Fixes #572 