### PR TITLE
Allow closing some menus with inventory/crafting keys

### DIFF
--- a/Minecraft.Client/Minecraft.cpp
+++ b/Minecraft.Client/Minecraft.cpp
@@ -1481,7 +1481,6 @@ void Minecraft::run_middle()
 								localplayers[i]->ullButtonsPressed|=1LL<<MINECRAFT_ACTION_USE;
 
 							bool isClosableByEitherKey = ui.IsSceneInStack(i, eUIScene_FurnaceMenu) ||
-								ui.IsSceneInStack(i, eUIScene_FurnaceMenu) ||
 								ui.IsSceneInStack(i, eUIScene_ContainerMenu) ||
 								ui.IsSceneInStack(i, eUIScene_DispenserMenu) ||
 								ui.IsSceneInStack(i, eUIScene_EnchantingMenu) ||


### PR DESCRIPTION
## Description
This PR improves UI interactions by allowing various container menus (such as Furnace, Chest, Dispenser, Anvil, etc.) to be closed using either the Inventory or Crafting keybinds. This change ensures that the menu closing behavior accurately aligns with the mechanics of current modern Minecraft versions.

## Changes

### Previous Behavior
Previously, pressing the Inventory key would only close the Inventory menu, and pressing the Crafting key would only close Crafting/Creative menus. Additionally, there was no safeguard to prevent these keybinds from triggering while the user was actively typing text (e.g., inside an Anvil).

### Root Cause
The keyboard input polling code in `Minecraft.cpp` (specifically inside the `_WINDOWS64` KBM input block) not written for this feature.

### New Behavior
Players can now interchangeably press either the Inventory key or the Crafting key to close most container menus (including Furnace, Container, Dispenser, Enchanting, Brewing Stand, Trading, Anvil, Hopper, Beacon, Inventory, and Horse). Furthermore, the menu will no longer close if the user is actively editing a text input field.

### Fix Implementation
- Added an `isClosableByEitherKey` check in `Minecraft.Client/Minecraft.cpp` to verify if the current UI scene is one of the supported container menus.
- Added an `isEditing` check using `isDirectEditBlocking()` on the top scene to determine if text input is currently active.
- Modified the condition blocks for `KEY_INVENTORY`, `KEY_CRAFTING`, and `KEY_CRAFTING_ALT` to incorporate these new checks.

### AI Use Disclosure
I used AI as a search tool to navigate the codebase.

## Related Issues
- Fixes #739 (https://github.com/smartcmd/MinecraftConsoles/issues/739)
