### PR TITLE
Use the correctly sized icons on 720p

### DIFF
--- a/Minecraft.Client/Common/UI/UIController.cpp
+++ b/Minecraft.Client/Common/UI/UIController.cpp
@@ -1814,8 +1814,8 @@ GDrawTexture * RADLINK UIController::TextureSubstitutionCreateCallback ( void * 
 
 	#if defined _WINDOWS64
             // Only set the size to 96x96 for 1080p on Windows
-            // This matches the logic defining m_loadedResolution in UIScene
-            if (uiController->getScreenHeight() > 720)
+            UIScene *scene = uiController->GetTopScene(0);
+            if (scene->getSceneResolution() == UIScene::eSceneResolution_1080)
             {
                 *width = 96;
                 *height = 96;


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Like the title says, this fixes an issue where if the game was running in 720p on windows the wrong-size icons would be used

## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->
<img width="574" height="490" alt="image" src="https://github.com/user-attachments/assets/6382519f-9512-483c-9b03-e7060a2455d6" />
<img width="650" height="588" alt="image" src="https://github.com/user-attachments/assets/12b1e1e7-6207-48c6-ae8f-2062a4dc82e7" />

### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->
We just always assumed the 96 size icons were correct for windows

### New Behavior
<!-- Describe how the code behaves after this change. -->
Only use the 96 size icons for 1080p and use the 64 size for 720p
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/be4e4436-2c2e-48f5-87b4-4f67d2161684" />


### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->
`uiController->getScreenHeight() > 720` matching `m_loadedResolution` in `UIScene`

### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->
None

## Related Issues
N/A
