### PR TITLE
Fix focus sound playing repeatedly on mouse hover

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene.cpp
+++ b/Minecraft.Client/Common/UI/UIScene.cpp
@@ -1331,11 +1331,17 @@ bool UIScene::hasRegisteredSubstitutionTexture(const wstring &textureName)
 
 void UIScene::_handleFocusChange(F64 controlId, F64 childId)
 {
-	m_iFocusControl = (int)controlId;
-	m_iFocusChild = (int)childId;
+	int newControl = (int)controlId;
+	int newChild = (int)childId;
 
-	handleFocusChange(controlId, childId);
-	ui.PlayUISFX(eSFX_Focus);
+	if (newControl != m_iFocusControl || newChild != m_iFocusChild)
+	{
+		m_iFocusControl = newControl;
+		m_iFocusChild = newChild;
+
+		handleFocusChange(controlId, childId);
+		ui.PlayUISFX(eSFX_Focus);
+	}
 }
 
 void UIScene::_handleInitFocus(F64 controlId, F64 childId)


### PR DESCRIPTION
## Description
Fixes the hover sound spamming rapidly when moving the mouse over the Texture Pack selector in the Create World menu. Reported on Discord.

## Changes

### Previous Behavior
The focus sound (`eSFX_Focus`) played on every focus event from IggyPlayer, even when the focus didn't actually change. Moving the mouse over the Texture Pack icons triggered dozens of focus events per second, causing a loud buzzing sound.

### Root Cause
`UIScene::_handleFocusChange()` unconditionally played the sound without checking if `controlId`/`childId` actually differed from the current focus.

### New Behavior
Sound only plays when the focus target actually changes. Hovering over the same element does not repeat the sound.

### Fix Implementation
Added a check in `_handleFocusChange()` that compares the new `controlId`/`childId` against the stored `m_iFocusControl`/`m_iFocusChild`. Only updates and plays the sound if they differ.

## Related Issues
- Reported on Discord (no GitHub issue)
