### PR TITLE
#790 Fix Adjustment - 100% Gamma is too Colorful & Too Dark/Not Bright at all. 

### DIFF
--- a/Minecraft.Client/GameRenderer.cpp
+++ b/Minecraft.Client/GameRenderer.cpp
@@ -945,9 +945,9 @@ float GameRenderer::ComputeGammaFromSlider(float slider0to100)
     slider = min(slider, 100.0f);
 
     if (slider > 50.0f)
-        return 1.0f + (slider - 50.0f) / 50.0f * 0.5f; // 1.0 -> 1.5
+        return 1.0f + (slider - 50.0f) / 50.0f * 1.2f; // 1.0 -> 1.5
     else
-        return 1.0f - (50.0f - slider) / 50.0f * 0.5f; // 1.0 -> 0.5
+        return 1.0f - (50.0f - slider) / 50.0f * 0.4f; // 1.0 -> 0.5
 }
 
 void GameRenderer::CachePlayerGammas()


### PR DESCRIPTION
## Description
This PR slightly fixes what #790 achieved. The gamma value was nerfed too low and now 100% gamma is not bright at all as originally intended.

100% gamma was not bright at all and was instead the original sweet spot for between bright but colorful.

## Changes
Increased the brightness impact of 0.5 to 1.2.
Lowered the <50% value from 0.5 to 0.4.

### Previous Behavior
100% gamma was not bright at all and was instead the original sweet spot for between bright but colorful.

### Root Cause
#790 lowered the slider value weight a bit too low.

### New Behavior
Now 100% Gamma is the brightness you would expect but not insane like pre-fix. Not the grounded colorful amount.

### Fix Implementation
Located the value modifier in GameRenderer and adjusted the brightness modifier from 0.5 to 1.2
I then lowered the <50% brightness modifier from 0.5 to 0.4.

### AI Use Disclosure
No AI was used.

## Related Issues
- Fixes #790 
- Related to #876 


<img width="1650" height="2500" alt="Screenshot 2026-03-07 193818" src="https://github.com/user-attachments/assets/88e15b23-d142-4fcc-a0c0-f73f607e8377" />


