### PR TITLE
Fix horse rendering: culling when looking up + fire debug texture

### DIFF
--- a/Minecraft.Client/HorseRenderer.cpp
+++ b/Minecraft.Client/HorseRenderer.cpp
@@ -55,8 +55,15 @@ void HorseRenderer::renderModel(shared_ptr<LivingEntity> mob, float wp, float ws
 
 void HorseRenderer::bindTexture(ResourceLocation *location)
 {
-	// Set up (potentially) multiple texture layers for the horse
-	entityRenderDispatcher->textures->bindTextureLayers(location);
+	if (location->getTextureCount() > 1)
+	{
+		// Set up multiple texture layers for the horse
+		entityRenderDispatcher->textures->bindTextureLayers(location);
+	}
+	else
+	{
+		EntityRenderer::bindTexture(location);
+	}
 }
 
 ResourceLocation *HorseRenderer::getTextureLocation(shared_ptr<Entity> entity)

--- a/Minecraft.Client/LevelRenderer.cpp
+++ b/Minecraft.Client/LevelRenderer.cpp
@@ -545,7 +545,8 @@ void LevelRenderer::renderEntities(Vec3 *cam, Culler *culler, float a)
 
 	for (auto& entity : entities)
 	{
-		bool shouldRender = (entity->shouldRender(cam) && (entity->noCulling || culler->isVisible(entity->bb)));
+		bool isPlayerVehicle = (entity == mc->cameraTargetPlayer->riding);
+		bool shouldRender = (entity->shouldRender(cam) && (entity->noCulling || isPlayerVehicle || culler->isVisible(entity->bb)));
 
 		// Render the mob if the mob's leash holder is within the culler
 		if ( !shouldRender && entity->instanceof(eTYPE_MOB) )


### PR DESCRIPTION
## Description
Fixes two horse rendering issues: the horse model disappearing when looking up while riding, and a debug texture showing instead of the fire overlay when a horse is on fire.

## Changes

### Fix 1: Horse disappears when looking up while riding

**Previous Behavior:**
The horse model would vanish when the player looked up while riding it.

**Root Cause:**
`LevelRenderer::renderEntities()` had no frustum culling exception for the entity the player is currently riding. The horse AABB ends at `horse.y + 1.6`, but the camera sits at `horse.y + 2.82`. When looking up, the entire horse AABB falls below the frustum and gets culled.

**Fix:**
Added an `isPlayerVehicle` check that skips frustum culling for the entity the player is riding.

### Fix 2: Debug texture when horse is on fire

**Previous Behavior:**
When a horse, mule, or donkey was set on fire, it displayed a broken/debug texture instead of the normal fire overlay.

| Before | After |
|--------|-------|
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/afe4e5ed-8660-4ba6-9531-ce15de08ebb1" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/7e4c091b-463c-446a-becc-92e63e38e6a2" /> |

**Root Cause:**
`HorseRenderer::bindTexture()` unconditionally calls `bindTextureLayers()`, even for single textures like the fire atlas. This reads the raw terrain.png instead of the runtime texture atlas.

**Fix:**
Modified `HorseRenderer::bindTexture()` to check `getTextureCount()`. Multi-layer horse textures still use `bindTextureLayers()`, single textures delegate to `EntityRenderer::bindTexture()`.

## Files Changed
- `Minecraft.Client/LevelRenderer.cpp` - Added `isPlayerVehicle` culling bypass
- `Minecraft.Client/HorseRenderer.cpp` - Fixed `bindTexture()` delegation

## Related Issues
- Reported on Discord (no GitHub issue)