### PR TITLE
fix: logo rendering order after closing host options

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene_InGameInfoMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_InGameInfoMenu.cpp
@@ -150,8 +150,6 @@ void UIScene_InGameInfoMenu::updateTooltips()
 void UIScene_InGameInfoMenu::handleDestroy()
 {
 	g_NetworkManager.UnRegisterPlayerChangedCallback(m_iPad, &UIScene_InGameInfoMenu::OnPlayerChanged, this);
-
-	m_parentLayer->removeComponent(eUIComponent_MenuBackground);
 }
 
 void UIScene_InGameInfoMenu::handleGainFocus(bool navBack)


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Fixed a UI rendering order bug where the game logo appeared darkened after opening and closing the Host Options menu.

## Changes

### Previous Behavior
When opening the pause menu after closing the host options menu, the background dimming effect would render on top of the game logo, making it look dark.

### Root Cause
`UIScene_InGameInfoMenu::handleDestroy` was calling `removeComponent(eUIComponent_MenuBackground)`. This forced the `UILayer` to recreate and re-insert the background at the end of the m_components vector, placing it above the Logo in the draw call stack.

### New Behavior
The logo now correctly renders on top of the background at all times, regardless of which menus were previously opened.

### Fix Implementation
Removed the unnecessary `removeComponent` call from `UIScene_InGameInfoMenu::handleDestroy`

### AI Use Disclosure
No

## Related Issues
- Fixes #885 
