### PR TITLE
Fix stale held item appearing when switching worlds

### DIFF
--- a/Minecraft.Client/ItemInHandRenderer.cpp
+++ b/Minecraft.Client/ItemInHandRenderer.cpp
@@ -930,6 +930,14 @@ void ItemInHandRenderer::tick()
 
 }
 
+void ItemInHandRenderer::reset()
+{
+	selectedItem = nullptr;
+	lastSlot = -1;
+	height = 0.0f;
+	oHeight = 0.0f;
+}
+
 void ItemInHandRenderer::itemPlaced()
 {
 	height = 0;

--- a/Minecraft.Client/ItemInHandRenderer.h
+++ b/Minecraft.Client/ItemInHandRenderer.h
@@ -41,6 +41,7 @@ private:
     int lastSlot;
 public:
 	void tick();
+	void reset();
     void itemPlaced();
     void itemUsed();
 };

--- a/Minecraft.Client/Minecraft.cpp
+++ b/Minecraft.Client/Minecraft.cpp
@@ -9,6 +9,7 @@
 #include "User.h"
 #include "Textures.h"
 #include "GameRenderer.h"
+#include "ItemInHandRenderer.h"
 #include "HumanoidModel.h"
 #include "Options.h"
 #include "TexturePackRepository.h"
@@ -216,6 +217,7 @@ Minecraft::Minecraft(Component *mouseComponent, Canvas *parent, MinecraftApplet 
 		m_pendingLocalConnections[i] = NULL;
 		m_connectionFailed[i] = false;
 		localgameModes[i]=NULL;
+		localitemInHandRenderers[i] = NULL;
 	}
 
 	animateTickLevel = NULL;	// 4J added
@@ -4225,6 +4227,17 @@ void Minecraft::setLevel(MultiPlayerLevel *level, int message /*=-1*/, shared_pt
 
 	// 4J - stop update thread from processing this level, which blocks until it is safe to move on - will be re-enabled if we set the level to be non-NULL
 	gameRenderer->DisableUpdateThread();
+
+	if (level == NULL || player == NULL)
+	{
+		for (int i = 0; i < XUSER_MAX_COUNT; ++i)
+		{
+			if (localitemInHandRenderers[i] != NULL)
+			{
+				localitemInHandRenderers[i]->reset();
+			}
+		}
+	}
 
 	for(unsigned int i = 0; i < levels.length; ++i)
 	{


### PR DESCRIPTION
## Description
This fixes a visual glitch where, when switching worlds, the previously held item could be visible for a bit before the new world's player state was applied.

## Changes

### Previous Behavior
The code would fail to clean up the player's held item state when exiting a world.

### Root Cause
`ItemInHandRenderer` cached held item states (`selectedItem`, `lastSlot`, and equip animation values) that persisted across world transitions and were reused before the new world's state fully propagated.

### New Behavior
Worlds now load with a cleared player state, so no stale items are shown before the correct ones are loaded.

### Fix Implementation
I added a `reset()` method to the `ItemInHandRenderer` which cleans up the player's held item state when a world is unloaded.

### AI Use Disclosure
I used AI as a tool to navigate the codebase and locate the areas that needed fixing, then implemented changes myself and tested the new behavior.

### How it looked before:
https://github.com/user-attachments/assets/7710a050-3e54-49d6-950d-0b25e72f6ec6

### How it looks after:
https://github.com/user-attachments/assets/7beda664-bc86-4034-a8a0-2dd56c3b34ff
