### PR TITLE
Added UI Scenes to exit with InventoryKey (KBM)

### DIFF
--- a/Minecraft.Client/Minecraft.cpp
+++ b/Minecraft.Client/Minecraft.cpp
@@ -1481,13 +1481,24 @@ void Minecraft::run_middle()
 
 							if(g_KBMInput.IsKeyPressed(KeyboardMouseInput::KEY_INVENTORY))
 							{
-								if(ui.IsSceneInStack(i, eUIScene_InventoryMenu))
+								if(
+									ui.IsSceneInStack(i, eUIScene_AnvilMenu) || 
+									ui.IsSceneInStack(i, eUIScene_BeaconMenu)  || 
+									ui.IsSceneInStack(i, eUIScene_BrewingStandMenu) || 
+									ui.IsSceneInStack(i, eUIScene_ContainerMenu) || 
+									ui.IsSceneInStack(i, eUIScene_DispenserMenu) || 
+									ui.IsSceneInStack(i, eUIScene_EnchantingMenu) || 
+									ui.IsSceneInStack(i, eUIScene_HopperMenu) || 
+									ui.IsSceneInStack(i, eUIScene_HorseMenu) || 
+									ui.IsSceneInStack(i, eUIScene_InventoryMenu) || 
+									ui.IsSceneInStack(i, eUIScene_FurnaceMenu) || 
+									ui.IsSceneInStack(i, eUIScene_TradingMenu))
 								{
 									ui.CloseUIScenes(i);
 								}
 								else
 								{
-									localplayers[i]->ullButtonsPressed|=1LL<<MINECRAFT_ACTION_INVENTORY;
+								localplayers[i]->ullButtonsPressed|=1LL<<MINECRAFT_ACTION_INVENTORY;
 								}
 							}
 


### PR DESCRIPTION
# Description
You can now exit the following menus with just pressing the InventoryKey like Java Edition.
- Anvil Menu
- Beacon Menu
- Brewing Stand Menu
- Chest Menu
- Dispenser Menu
- Dropper Menu
- Enchanting Table Menu
- Hopper Menu
- Horse/Donkey Menu
- Furnace Menu
- Villager Trade Menu

## Tests
- This does not affect the Q/E Tab Combo in the Crafting Table / Creative Menu
- All items have been tested and worked
<img width="400" height="370" alt="image" src="https://github.com/user-attachments/assets/39ec3b76-2b3a-420d-80a1-64f157edbc44" />

## Changes
Added those scenes to the list of menus that you exit out of when pressing InventoryKey.

### Previous Behavior
You had to press ESC to exit out of everything which is very cumbersome.

InventoryKey only let you exit out of your Inventory.

### Root Cause
Lack of addtional checks for what UIScene the player was in.

### New Behavior
Now you exit out of the list above by simply pressing the InventoryKey like Java Edition.

### Fix Implementation
In Minecraft.cpp, I added additional scenes to the InventoryKey Pressed Check.

Due to the list being a tad long, I organized them into a list of OR statements.


### AI Use Disclosure
No AI was used.

## Related Issues
None.
