### PR TITLE
fix: disable on-screen button binds in Keyboard PC mode

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene_Keyboard.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_Keyboard.cpp
@@ -211,23 +211,30 @@ void UIScene_Keyboard::handleInput(int iPad, int key, bool repeat, bool pressed,
 
 	if(repeat || pressed)
 	{
-		switch(key)
+		if (key == ACTION_MENU_CANCEL)
 		{
-		case ACTION_MENU_CANCEL:
 #ifdef _WINDOWS64
-			{
-				// Cache before navigateBack() destroys this scene
-				int(*cb)(LPVOID, const bool) = m_win64Callback;
-				LPVOID cbParam = m_win64CallbackParam;
-				navigateBack();
-				if (cb)
-					cb(cbParam, false);
-			}
+			// Cache before navigateBack() destroys this scene
+			int(*cb)(LPVOID, const bool) = m_win64Callback;
+			LPVOID cbParam = m_win64CallbackParam;
+			navigateBack();
+			if (cb)
+				cb(cbParam, false);
 #else
 			navigateBack();
 #endif
 			handled = true;
-			break;
+			return;
+		}
+
+		// Don't handle on-screen buttons
+		if (m_bPCMode)
+		{
+			return;
+		}
+
+		switch(key)
+		{
 		case ACTION_MENU_X:					// X
 			out = IggyPlayerCallMethodRS ( getMovie() , &result, IggyPlayerRootPath( getMovie() ), m_funcBackspaceButtonPressed, 0 , NULL );
 			handled = true;


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Fixed a bug in the on-screen keyboard where physical key presses (like R, Tab, Q, E) would trigger on-screen button actions (backspace, space, etc.) while in pc typing mode.

## Changes

### Previous Behavior
In pc mode, pressing certain physical keys would perform two actions simultaneously. For example pressing R would type 'r' but also trigger backspace or pressing tab would type a space.

### Root Cause
`UIScene_Keyboard::handleInput` was processing `ACTION_MENU_X`, `ACTION_MENU_Y`, etc., and calling their associated methods (`m_funcBackspaceButtonPressed`, etc.) even when `m_bPCMode` was active

### New Behavior
In PC mode, physical keys only result in character input

### Fix Implementation
Added an early return in `UIScene_Keyboard::handleInput` that prevents the execution of on-screen button functions when `m_bPCMode` is enabled. The `ACTION_MENU_CANCEL` check remains at the top to ensure the menu can still be closed via the Escape key.

### AI Use Disclosure
No

## Related Issues
- Fixes #912 
