### PR TITLE
fix: prevent TNT minecarts from exploding if TNT host option is disabled

### DIFF
--- a/Minecraft.World/MinecartTNT.cpp
+++ b/Minecraft.World/MinecartTNT.cpp
@@ -80,9 +80,12 @@ void MinecartTNT::explode(double speedSqr)
 	if (!level->isClientSide)
 	{
 		double speed = sqrt(speedSqr);
-		if (speed > 5) speed = 5;
-		level->explode(shared_from_this(), x, y, z, (float) (4 + random->nextDouble() * 1.5f * speed), true);
-		remove();
+		if (speed > 5.0) speed = 5.0;
+		if (app.GetGameHostOption(eGameHostOption_TNT))
+		{
+			level->explode(shared_from_this(), x, y, z, (float) (4 + random->nextDouble() * 1.5f * speed), true);
+			remove();
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Fixed a gameplay inconsistency where TNT Minecarts would ignore the "TNT Explodes" host option, allowing them to explode even when TNT was disabled for the world.

## Changes

### Previous Behavior
TNT Minecarts would always explode regardless of the world's host settings. This allowed for accidental or intentional griefing in worlds where the host specifically disabled TNT.

### Root Cause
The `MinecartTNT::explode` function lacked a check for the `eGameHostOption_TNT` flag

### New Behavior
TNT Minecarts now respect the TNT explodes option.

### Fix Implementation
Wrapped the explosion and entity removal logic inside a conditional check for `app.GetGameHostOption(eGameHostOption_TNT)`

### AI Use Disclosure
No

## Related Issues
- Fixes #904 