### PR TITLE
Creative Mode Key Swap - KBM QoL

### DIFF
--- a/Minecraft.Client/Minecraft.cpp
+++ b/Minecraft.Client/Minecraft.cpp
@@ -1485,6 +1485,10 @@ void Minecraft::run_middle()
 								{
 									ui.CloseUIScenes(i);
 								}
+								else if(gameMode->hasInfiniteItems())
+								{
+									localplayers[i]->ullButtonsPressed|=1LL<<MINECRAFT_ACTION_CRAFTING;
+								}
 								else
 								{
 									localplayers[i]->ullButtonsPressed|=1LL<<MINECRAFT_ACTION_INVENTORY;
@@ -1499,6 +1503,10 @@ void Minecraft::run_middle()
 							if(ui.IsSceneInStack(i, eUIScene_Crafting2x2Menu) || ui.IsSceneInStack(i, eUIScene_Crafting3x3Menu) || ui.IsSceneInStack(i, eUIScene_CreativeMenu))
 							{
 								ui.CloseUIScenes(i);
+							}
+							else if(gameMode->hasInfiniteItems())
+							{
+								localplayers[i]->ullButtonsPressed|=1LL<<MINECRAFT_ACTION_INVENTORY;
 							}
 							else
 							{


### PR DESCRIPTION
## Description
When in Creative Mode, pressing the InventoryKey will open the CreativeMenu instead of the Inventory.

This is similar to Java, and I think Bedrock?

If you press the CraftKey in Creative Mode, it will open your inventory.
- This does not interfere with controller as this is a change to the added KBM Inputs.
- This does not interfere with #916 
- This has been tested in both Creative and Survival.
- This does not disrupt gameplay flow, such as a menu instantly popping up upon another, etc.
- This does not affect the Q/E Tab Combo in the Crafting Table / Creative Menu

## Changes
Added additional checks in the KBM input section.

### Previous Behavior
Pressing InventoryKey in Creative would open inventory.
Pressing CraftKey in Creative would open Creative Menu.

### Root Cause
Lack of addtional checks for gamemode of player.

### New Behavior
Pressing InventoryKey in Creative would open Creative Menu.
Pressing CraftKey in Creative would open inventory.

### Fix Implementation
In Minecraft.cpp, added additional IF-ELSE statements to check whether the player is in creative when they pressed a certain KBM action.

This logic does not disrupt gameplay as these are just button action links in the KBM Input Addition.

### AI Use Disclosure
No AI.

## Related Issues
No relations or solutions.
