### PR TITLE
Fix missing break statement for minecarts

### DIFF
--- a/Minecraft.Client/ClientConnection.cpp
+++ b/Minecraft.Client/ClientConnection.cpp
@@ -427,6 +427,7 @@ void ClientConnection::handleAddEntity(shared_ptr<AddEntityPacket> packet)
 	{
 	case AddEntityPacket::MINECART:
 		e = Minecart::createMinecart(level, x, y, z, packet->data);
+		break;
 	case AddEntityPacket::FISH_HOOK:
 		{
 			// 4J Stu - Brought forward from 1.4 to be able to drop XP from fishing


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
There was a missing `break;` statement, causing minecarts to show up as fishing bobbers.

## Changes

### Previous Behavior
Chest minecarts to show up as fishing bobbers.

### Root Cause
Missing break statement.

### New Behavior
Chest minecarts will not show up as fishing bobbers.

### Fix Implementation
Adding the `break ;` statement

### AI Use Disclosure
No AI was needed for this

<img width="1919" height="1079" alt="fixxxx" src="https://github.com/user-attachments/assets/73bb711c-2aba-43b0-bb91-28ba9e13ce83" />

