### PR TITLE
Fix second-person nametag pitch

### DIFF
--- a/Minecraft.Client/EntityRenderDispatcher.cpp
+++ b/Minecraft.Client/EntityRenderDispatcher.cpp
@@ -234,6 +234,7 @@ void EntityRenderDispatcher::prepare(Level *level, Textures *textures, Font *fon
 	if (pl->ThirdPersonView() == 2)
 	{
 		playerRotY += 180;
+		playerRotX = -playerRotX;
 	}
 
 	xPlayer = player->xOld + (player->x - player->xOld) * a;


### PR DESCRIPTION
## Description
This PR fixes a visual bug where the rotation of nametags would be incorrectly calculated for the second-person view.

## Changes

### Previous Behavior
In second-person view (`ThirdPersonView() == 2`), nametags pitched the wrong way. Looking down caused the billboard to tilt down instead of up (and vice versa).

### Root Cause
`EntityRenderDispatcher::prepare()` only adjusted yaw (`playerRotY += 180`) and did not mirror pitch. Billboarded renders use `playerRotX`/`playerRotY`, so an incorrect vale of `playerRotX` meant they no longer matched the actual camera transform.

### New Behavior
In second-person view, nametags now stay correctly aligned with the camera pitch and no longer appear inverted.

### Fix Implementation
Updated `EntityRenderDispatcher::prepare()` so when `ThirdPersonView() == 2`, it now flips pitch as well, by adding `playerRotX = -playerRotX`.

### AI Use Disclosure
I used AI as a tool to search for the relevant rendering code, then located the specific lines that needed fixing and implemented the fix by myself.

## Related Issues
- Fixes #948 

## How it looked before:
<img width="653" height="442" alt="image" src="https://github.com/user-attachments/assets/baae4939-2562-4369-a393-f248639f8b3e" />

## How it looks after:
<img width="639" height="408" alt="image" src="https://github.com/user-attachments/assets/840848dc-2bf8-4e93-a75a-8ddee8808128" />
