### PR TITLE
Fix mounted minecarts not persisting across world reloads

### DIFF
--- a/Minecraft.World/LevelChunk.cpp
+++ b/Minecraft.World/LevelChunk.cpp
@@ -1222,6 +1222,30 @@ void LevelChunk::addEntity(shared_ptr<Entity> e)
 #endif
 }
 
+void LevelChunk::addRidingEntities(shared_ptr<Entity> rider, CompoundTag *riderTag)
+{
+#ifdef _LARGE_WORLDS #This shouldnt be called when we dont have large worlds enabled
+    CompoundTag *mountTag = riderTag;
+    shared_ptr<Entity> ridingEntity = rider;
+
+    while (mountTag != NULL && mountTag->contains(Entity::RIDING_TAG))
+    {
+        CompoundTag *nextMountTag = mountTag->getCompound(Entity::RIDING_TAG);
+        shared_ptr<Entity> mount = EntityIO::loadStatic(nextMountTag, level);
+        if (mount == NULL)
+        {
+            break;
+        }
+
+        mount->onLoadedFromSave();
+        addEntity(mount);
+        ridingEntity->ride(mount);
+
+        ridingEntity = mount;
+        mountTag = nextMountTag;
+    }
+#endif
+};
 
 void LevelChunk::removeEntity(shared_ptr<Entity> e)
 {
@@ -1420,29 +1444,6 @@ void LevelChunk::load()
 #ifdef _LARGE_WORLDS
 		if(m_bUnloaded && m_unloadedEntitiesTag)
 		{
-			auto addRidingEntities = [this](shared_ptr<Entity> rider, CompoundTag *riderTag)
-			{
-				CompoundTag *mountTag = riderTag;
-				shared_ptr<Entity> ridingEntity = rider;
-
-				while (mountTag != NULL && mountTag->contains(Entity::RIDING_TAG))
-				{
-					CompoundTag *nextMountTag = mountTag->getCompound(Entity::RIDING_TAG);
-					shared_ptr<Entity> mount = EntityIO::loadStatic(nextMountTag, level);
-					if (mount == NULL)
-					{
-						break;
-					}
-
-					mount->onLoadedFromSave();
-					addEntity(mount);
-					ridingEntity->ride(mount);
-
-					ridingEntity = mount;
-					mountTag = nextMountTag;
-				}
-			};
-
 			ListTag<CompoundTag> *entityTags = (ListTag<CompoundTag> *) m_unloadedEntitiesTag->getList(L"Entities");
 			if (entityTags != NULL)
 			{

--- a/Minecraft.World/LevelChunk.h
+++ b/Minecraft.World/LevelChunk.h
@@ -192,6 +192,7 @@ public:
 	virtual void setBrightness(LightLayer::variety layer, int x, int y, int z, int brightness);
 	virtual int getRawBrightness(int x, int y, int z, int skyDampen);
 	virtual void addEntity(shared_ptr<Entity> e);
+    virtual void addRidingEntities(shared_ptr<Entity> rider, CompoundTag *riderTag);
 	virtual void removeEntity(shared_ptr<Entity> e);
 	virtual void removeEntity(shared_ptr<Entity> e, int yc);
 	virtual bool isSkyLit(int x, int y, int z);

--- a/Minecraft.World/OldChunkStorage.cpp
+++ b/Minecraft.World/OldChunkStorage.cpp
@@ -392,28 +392,6 @@ void OldChunkStorage::save(LevelChunk *lc, Level *level, CompoundTag *tag)
 
 void OldChunkStorage::loadEntities(LevelChunk *lc, Level *level, CompoundTag *tag)
 {
-	auto addRidingEntities = [lc, level](shared_ptr<Entity> rider, CompoundTag *riderTag)
-	{
-		CompoundTag *mountTag = riderTag;
-		shared_ptr<Entity> ridingEntity = rider;
-
-		while (mountTag != NULL && mountTag->contains(Entity::RIDING_TAG))
-		{
-			CompoundTag *nextMountTag = mountTag->getCompound(Entity::RIDING_TAG);
-			shared_ptr<Entity> mount = EntityIO::loadStatic(nextMountTag, level);
-			if (mount == NULL)
-			{
-				break;
-			}
-
-			lc->addEntity(mount);
-			ridingEntity->ride(mount);
-
-			ridingEntity = mount;
-			mountTag = nextMountTag;
-		}
-	};
-
 	ListTag<CompoundTag> *entityTags = (ListTag<CompoundTag> *) tag->getList(L"Entities");
 	if (entityTags != NULL)
 	{
@@ -425,7 +403,7 @@ void OldChunkStorage::loadEntities(LevelChunk *lc, Level *level, CompoundTag *ta
 			if (te != NULL)
 			{
 				lc->addEntity(te);
-				addRidingEntities(te, teTag);
+				lc->addRidingEntities(te, teTag);
 			}
 		}
 	}

--- a/Minecraft.World/ZonedChunkStorage.cpp
+++ b/Minecraft.World/ZonedChunkStorage.cpp
@@ -184,28 +184,6 @@ void ZonedChunkStorage::flush()
 
 void ZonedChunkStorage::loadEntities(Level *level, LevelChunk *lc)
 {
-    auto addRidingEntities = [level, lc](shared_ptr<Entity> rider, CompoundTag *riderTag)
-    {
-        CompoundTag *mountTag = riderTag;
-        shared_ptr<Entity> ridingEntity = rider;
-
-        while (mountTag != NULL && mountTag->contains(Entity::RIDING_TAG))
-        {
-            CompoundTag *nextMountTag = mountTag->getCompound(Entity::RIDING_TAG);
-            shared_ptr<Entity> mount = EntityIO::loadStatic(nextMountTag, level);
-            if (mount == nullptr)
-            {
-                break;
-            }
-
-            lc->addEntity(mount);
-            ridingEntity->ride(mount);
-
-            ridingEntity = mount;
-            mountTag = nextMountTag;
-        }
-    };
-
     int slot = getSlot(lc->x, lc->z);
     ZoneFile *zoneFile = getZoneFile(lc->x, lc->z, true);
     vector<CompoundTag *> *tags = zoneFile->entityFile->readAll(slot);
@@ -219,7 +197,7 @@ void ZonedChunkStorage::loadEntities(Level *level, LevelChunk *lc)
             if (e != nullptr)
             {
                 lc->addEntity(e);
-                addRidingEntities(e, tag);
+                lc->addRidingEntities(e, tag);
             }
         }
 		else if (type == 1)


### PR DESCRIPTION
## Description
This PR fixes an issue where minecarts with riders would not spawn in properly upon loading a world.

## Changes

### Previous Behavior
If an entity was riding a minecart when the world was saved, reopening the world could leave the rider unmounted and the minecart missing. Minecarts without riders persisted normally.

### Root Cause
Mounted minecarts were saved through the rider’s NBT data, but chunk entity loading only restored top-level entities and did not rebuild that chain.

### New Behavior
When a world is reloaded, entities saved with mounts correctly restore their full riding chain, so ridden minecarts are present and still mounted.

### Fix Implementation
Added riding chain reconstruction during chunk entity load in all relevant paths:
- OldChunkStorage::loadEntities
- LevelChunk::load
- ZonedChunkStorage::loadEntities

Each loader now goes through `Entity::RIDING_TAG`, loads each mount entity, adds it to the chunk, and links them properly.

### AI Use Disclosure
I used AI as a tool to search for the chunk entity loading logic, then implemented the fix myself.

## Related Issues
- Fixes #970 