### PR TITLE
Fix crash when launching at 720p or lower resolutions

### DIFF
--- a/Minecraft.Client/Common/UI/UIController.cpp
+++ b/Minecraft.Client/Common/UI/UIController.cpp
@@ -529,43 +529,24 @@ void UIController::loadSkins()
 #elif defined __PSVITA__
 	platformSkinPath = L"skinVita.swf";
 #elif defined _WINDOWS64
-	if(m_fScreenHeight>720.0f)
-	{
-		platformSkinPath = L"skinHDWin.swf";
-	}
-	else
-	{
-		platformSkinPath = L"skinWin.swf";
-	}
+	// Windows64/Durango/Orbis always load HD skin libraries unconditionally,
+	// which import "platformskinHD.swf" by name.  The platform skin must
+	// therefore always be the HD variant regardless of screen resolution.
+	platformSkinPath = L"skinHDWin.swf";
 #elif defined _DURANGO
-	if(m_fScreenHeight>720.0f)
-	{
-		platformSkinPath = L"skinHDDurango.swf";
-	}
-	else
-	{
-		platformSkinPath = L"skinDurango.swf";
-	}
+	platformSkinPath = L"skinHDDurango.swf";
 #elif defined __ORBIS__
-	if(m_fScreenHeight>720.0f)
-	{
-		platformSkinPath = L"skinHDOrbis.swf";
-	}
-	else
-	{
-		platformSkinPath = L"skinOrbis.swf";
-	}
+	platformSkinPath = L"skinHDOrbis.swf";
 
 #endif
-	// Every platform has one of these, so nothing shared
-	if(m_fScreenHeight>720.0f)
-	{
-		m_iggyLibraries[eLibrary_Platform] = loadSkin(platformSkinPath, L"platformskinHD.swf");
-	}
-	else
-	{
-		m_iggyLibraries[eLibrary_Platform] = loadSkin(platformSkinPath, L"platformskin.swf");
-	}
+	// Every platform has one of these, so nothing shared.
+	// On HD platforms (Win64/Durango/Orbis) the skin libraries always import
+	// "platformskinHD.swf", so we must register under that name at any resolution.
+#if defined(_WINDOWS64) || defined(_DURANGO) || defined(__ORBIS__)
+	m_iggyLibraries[eLibrary_Platform] = loadSkin(platformSkinPath, L"platformskinHD.swf");
+#else
+	m_iggyLibraries[eLibrary_Platform] = loadSkin(platformSkinPath, L"platformskin.swf");
+#endif
 
 #if defined(__PS3__) || defined(__PSVITA__)
 	m_iggyLibraries[eLibrary_GraphicsDefault] = loadSkin(L"skinGraphics.swf", L"skinGraphics.swf");


### PR DESCRIPTION
## Description

Fix crash on startup when the game window is at 720p or below on Windows64.

## Changes

### Previous Behavior

Launching the game at 1280x720 or any resolution with height ≤720 caused an immediate crash during UI initialization. Iggy reported "Attempted to import undefined library platformskinHD.swf", followed by "Failed to load iggy scene!" and a `__debugbreak()` in `UIScene::loadMovie()`.

### Root Cause

In `UIController::loadSkins()`, the platform skin path and its Iggy registration name were chosen based on a runtime check (`m_fScreenHeight > 720.0f`). At 720p this evaluates to false, so the skin was loaded from `skinWin.swf` and registered as `"platformskin.swf"`. Below 720p, the same non-HD path was taken.

However, further down in the same function, the HD skin libraries (`skinHD.swf`, `skinHDHud.swf`, `skinHDInGame.swf`, etc.) are loaded **unconditionally** on Win64/Durango/Orbis — there is no resolution gate around them. These SWFs internally `import platformskinHD.swf`, which was never registered at ≤720p, causing Iggy to fail the import and every dependent scene to fail loading.

This is an original 4J bug — the HD block was written assuming these platforms always run above 720p, which is true for consoles but not for PC where the window can be any size.

### New Behavior

The game starts and runs correctly at any resolution on Windows64, including 720p and 480p.

### Fix Implementation

Removed the runtime resolution conditional for the platform skin path on Win64/Durango/Orbis. These platforms now always load the HD variant (`skinHDWin.swf` / `skinHDDurango.swf` / `skinHDOrbis.swf`) and always register it as `"platformskinHD.swf"`, matching what the unconditionally-loaded HD skin libraries expect. The registration was changed from a runtime `if` to a compile-time `#if` to make the platform split explicit. PS3/PSVita are unaffected as they have their own separate non-HD skin loading path.

### AI Use Disclosure

No AI was used to write the code in this PR.

## Related Issues
- Fixes #949
