### PR TITLE
Revert the workaround of loading of hd textures

### DIFF
--- a/Minecraft.Client/Common/UI/UIController.cpp
+++ b/Minecraft.Client/Common/UI/UIController.cpp
@@ -522,33 +522,9 @@ void UIController::tick()
 
 void UIController::loadSkins()
 {
-	wstring platformSkinPath = L"";
-
 #ifdef __PS3__
-	platformSkinPath = L"skinPS3.swf";
-#elif defined __PSVITA__
-	platformSkinPath = L"skinVita.swf";
-#elif defined _WINDOWS64
-	// Windows64/Durango/Orbis always load HD skin libraries unconditionally,
-	// which import "platformskinHD.swf" by name.  The platform skin must
-	// therefore always be the HD variant regardless of screen resolution.
-	platformSkinPath = L"skinHDWin.swf";
-#elif defined _DURANGO
-	platformSkinPath = L"skinHDDurango.swf";
-#elif defined __ORBIS__
-	platformSkinPath = L"skinHDOrbis.swf";
+	m_iggyLibraries[eLibrary_Platform] = loadSkin(L"skinPS3.swf", L"platformskin.swf");
 
-#endif
-	// Every platform has one of these, so nothing shared.
-	// On HD platforms (Win64/Durango/Orbis) the skin libraries always import
-	// "platformskinHD.swf", so we must register under that name at any resolution.
-#if defined(_WINDOWS64) || defined(_DURANGO) || defined(__ORBIS__)
-	m_iggyLibraries[eLibrary_Platform] = loadSkin(platformSkinPath, L"platformskinHD.swf");
-#else
-	m_iggyLibraries[eLibrary_Platform] = loadSkin(platformSkinPath, L"platformskin.swf");
-#endif
-
-#if defined(__PS3__) || defined(__PSVITA__)
 	m_iggyLibraries[eLibrary_GraphicsDefault] = loadSkin(L"skinGraphics.swf", L"skinGraphics.swf");
 	m_iggyLibraries[eLibrary_GraphicsHUD] = loadSkin(L"skinGraphicsHud.swf", L"skinGraphicsHud.swf");
 	m_iggyLibraries[eLibrary_GraphicsInGame] = loadSkin(L"skinGraphicsInGame.swf", L"skinGraphicsInGame.swf");
@@ -559,13 +535,28 @@ void UIController::loadSkins()
 	m_iggyLibraries[eLibrary_HUD] = loadSkin(L"skinHud.swf", L"skinHud.swf");
 	m_iggyLibraries[eLibrary_Tooltips] = loadSkin(L"skinTooltips.swf", L"skinTooltips.swf");
 	m_iggyLibraries[eLibrary_Default] = loadSkin(L"skin.swf", L"skin.swf");
-#endif
 
-#if ( defined(_WINDOWS64) || defined(_DURANGO) || defined(__ORBIS__) )
+#elif defined __PSVITA__
+	m_iggyLibraries[eLibrary_Platform] = loadSkin(L"skinVita.swf", L"platformskin.swf");
 
-#if defined(_WINDOWS64)
-	// 4J Stu - Load the 720/480 skins so that we have something to fallback on during development
-#ifndef _FINAL_BUILD
+	m_iggyLibraries[eLibrary_GraphicsDefault] = loadSkin(L"skinGraphics.swf", L"skinGraphics.swf");
+	m_iggyLibraries[eLibrary_GraphicsHUD] = loadSkin(L"skinGraphicsHud.swf", L"skinGraphicsHud.swf");
+	m_iggyLibraries[eLibrary_GraphicsInGame] = loadSkin(L"skinGraphicsInGame.swf", L"skinGraphicsInGame.swf");
+	m_iggyLibraries[eLibrary_GraphicsTooltips] = loadSkin(L"skinGraphicsTooltips.swf", L"skinGraphicsTooltips.swf");
+	m_iggyLibraries[eLibrary_GraphicsLabels] = loadSkin(L"skinGraphicsLabels.swf", L"skinGraphicsLabels.swf");
+	m_iggyLibraries[eLibrary_Labels] = loadSkin(L"skinLabels.swf", L"skinLabels.swf");
+	m_iggyLibraries[eLibrary_InGame] = loadSkin(L"skinInGame.swf", L"skinInGame.swf");
+	m_iggyLibraries[eLibrary_HUD] = loadSkin(L"skinHud.swf", L"skinHud.swf");
+	m_iggyLibraries[eLibrary_Tooltips] = loadSkin(L"skinTooltips.swf", L"skinTooltips.swf");
+	m_iggyLibraries[eLibrary_Default] = loadSkin(L"skin.swf", L"skin.swf");
+
+#elif defined _WINDOWS64
+	// HD platform skin — required by skinHD*.swf (1080p scene SWFs)
+	m_iggyLibraries[eLibrary_Platform] = loadSkin(L"skinHDWin.swf", L"platformskinHD.swf");
+	// Non-HD platform skin — required by skin*.swf (720p/480p scene SWFs)
+	m_iggyLibraries[eLibraryFallback_Platform] = loadSkin(L"skinWin.swf", L"platformskin.swf");
+
+	// Non-HD skin set (720p/480p scenes import these)
 	m_iggyLibraries[eLibraryFallback_GraphicsDefault] = loadSkin(L"skinGraphics.swf", L"skinGraphics.swf");
 	m_iggyLibraries[eLibraryFallback_GraphicsHUD] = loadSkin(L"skinGraphicsHud.swf", L"skinGraphicsHud.swf");
 	m_iggyLibraries[eLibraryFallback_GraphicsInGame] = loadSkin(L"skinGraphicsInGame.swf", L"skinGraphicsInGame.swf");
@@ -576,8 +567,21 @@ void UIController::loadSkins()
 	m_iggyLibraries[eLibraryFallback_HUD] = loadSkin(L"skinHud.swf", L"skinHud.swf");
 	m_iggyLibraries[eLibraryFallback_Tooltips] = loadSkin(L"skinTooltips.swf", L"skinTooltips.swf");
 	m_iggyLibraries[eLibraryFallback_Default] = loadSkin(L"skin.swf", L"skin.swf");
-#endif
-#endif
+
+	// HD skin set (1080p scenes import these)
+	m_iggyLibraries[eLibrary_GraphicsDefault] = loadSkin(L"skinHDGraphics.swf", L"skinHDGraphics.swf");
+	m_iggyLibraries[eLibrary_GraphicsHUD] = loadSkin(L"skinHDGraphicsHud.swf", L"skinHDGraphicsHud.swf");
+	m_iggyLibraries[eLibrary_GraphicsInGame] = loadSkin(L"skinHDGraphicsInGame.swf", L"skinHDGraphicsInGame.swf");
+	m_iggyLibraries[eLibrary_GraphicsTooltips] = loadSkin(L"skinHDGraphicsTooltips.swf", L"skinHDGraphicsTooltips.swf");
+	m_iggyLibraries[eLibrary_GraphicsLabels] = loadSkin(L"skinHDGraphicsLabels.swf", L"skinHDGraphicsLabels.swf");
+	m_iggyLibraries[eLibrary_Labels] = loadSkin(L"skinHDLabels.swf", L"skinHDLabels.swf");
+	m_iggyLibraries[eLibrary_InGame] = loadSkin(L"skinHDInGame.swf", L"skinHDInGame.swf");
+	m_iggyLibraries[eLibrary_HUD] = loadSkin(L"skinHDHud.swf", L"skinHDHud.swf");
+	m_iggyLibraries[eLibrary_Tooltips] = loadSkin(L"skinHDTooltips.swf", L"skinHDTooltips.swf");
+	m_iggyLibraries[eLibrary_Default] = loadSkin(L"skinHD.swf", L"skinHD.swf");
+
+#elif defined _DURANGO
+	m_iggyLibraries[eLibrary_Platform] = loadSkin(L"skinHDDurango.swf", L"platformskinHD.swf");
 
 	m_iggyLibraries[eLibrary_GraphicsDefault] = loadSkin(L"skinHDGraphics.swf", L"skinHDGraphics.swf");
 	m_iggyLibraries[eLibrary_GraphicsHUD] = loadSkin(L"skinHDGraphicsHud.swf", L"skinHDGraphicsHud.swf");
@@ -589,7 +593,21 @@ void UIController::loadSkins()
 	m_iggyLibraries[eLibrary_HUD] = loadSkin(L"skinHDHud.swf", L"skinHDHud.swf");
 	m_iggyLibraries[eLibrary_Tooltips] = loadSkin(L"skinHDTooltips.swf", L"skinHDTooltips.swf");
 	m_iggyLibraries[eLibrary_Default] = loadSkin(L"skinHD.swf", L"skinHD.swf");
-#endif // HD platforms
+
+#elif defined __ORBIS__
+	m_iggyLibraries[eLibrary_Platform] = loadSkin(L"skinHDOrbis.swf", L"platformskinHD.swf");
+
+	m_iggyLibraries[eLibrary_GraphicsDefault] = loadSkin(L"skinHDGraphics.swf", L"skinHDGraphics.swf");
+	m_iggyLibraries[eLibrary_GraphicsHUD] = loadSkin(L"skinHDGraphicsHud.swf", L"skinHDGraphicsHud.swf");
+	m_iggyLibraries[eLibrary_GraphicsInGame] = loadSkin(L"skinHDGraphicsInGame.swf", L"skinHDGraphicsInGame.swf");
+	m_iggyLibraries[eLibrary_GraphicsTooltips] = loadSkin(L"skinHDGraphicsTooltips.swf", L"skinHDGraphicsTooltips.swf");
+	m_iggyLibraries[eLibrary_GraphicsLabels] = loadSkin(L"skinHDGraphicsLabels.swf", L"skinHDGraphicsLabels.swf");
+	m_iggyLibraries[eLibrary_Labels] = loadSkin(L"skinHDLabels.swf", L"skinHDLabels.swf");
+	m_iggyLibraries[eLibrary_InGame] = loadSkin(L"skinHDInGame.swf", L"skinHDInGame.swf");
+	m_iggyLibraries[eLibrary_HUD] = loadSkin(L"skinHDHud.swf", L"skinHDHud.swf");
+	m_iggyLibraries[eLibrary_Tooltips] = loadSkin(L"skinHDTooltips.swf", L"skinHDTooltips.swf");
+	m_iggyLibraries[eLibrary_Default] = loadSkin(L"skinHD.swf", L"skinHD.swf");
+#endif
 }
 
 IggyLibrary UIController::loadSkin(const wstring &skinPath, const wstring &skinName)

--- a/Minecraft.Client/Common/UI/UIController.h
+++ b/Minecraft.Client/Common/UI/UIController.h
@@ -101,9 +101,8 @@ private:
 		eLibrary_Tooltips,
 		eLibrary_Default,
 
-#if ( defined(_WINDOWS64) )
-	// 4J Stu - Load the 720/480 skins so that we have something to fallback on during development
-#ifndef _FINAL_BUILD
+#if defined(_WINDOWS64)
+		// Non-HD skin libraries needed by 720p/480p scene SWFs.
 		eLibraryFallback_Platform,
 		eLibraryFallback_GraphicsDefault,
 		eLibraryFallback_GraphicsHUD,
@@ -115,7 +114,6 @@ private:
 		eLibraryFallback_HUD,
 		eLibraryFallback_Tooltips,
 		eLibraryFallback_Default,
-#endif
 #endif
 
 		eLibrary_Count,

--- a/Minecraft.Client/Common/UI/UIScene.cpp
+++ b/Minecraft.Client/Common/UI/UIScene.cpp
@@ -286,8 +286,16 @@ void UIScene::loadMovie()
 	moviePath.append(L"Vita.swf");
 	m_loadedResolution = eSceneResolution_Vita;
 #elif defined _WINDOWS64
-	moviePath.append(L"1080.swf");
-	m_loadedResolution = eSceneResolution_1080;
+	if(ui.getScreenHeight() > 720.0f)
+	{
+		moviePath.append(L"1080.swf");
+		m_loadedResolution = eSceneResolution_1080;
+	}
+	else
+	{
+		moviePath.append(L"720.swf");
+		m_loadedResolution = eSceneResolution_720;
+	}
 #else
 	moviePath.append(L"1080.swf");
 	m_loadedResolution = eSceneResolution_1080;


### PR DESCRIPTION
## Description

Fix blurry UI at sub-HD resolutions on Win64 by loading both HD and non-HD skin sets and picking the right scene SWF based on actual screen height.

## Changes

### Previous Behavior

The earlier crash fix (from #981) forced HD skins at every resolution to prevent Iggy from failing to resolve `platformskinHD.swf`. This fixed the crash but at 720p and below Iggy was downscaling 1080p assets and everything looked blurry.

### Root Cause

Two issues, both from 4J's original code:

1. The HD skin libraries (`skinHD.swf`, `skinHDHud.swf`, etc.) are loaded unconditionally on Win64/Durango/Orbis. These SWFs internally `import platformskinHD.swf`. But the platform skin registration was behind a runtime resolution check — at <=720p it registered `skinWin.swf` as `platformskin.swf` instead of `platformskinHD.swf`, so Iggy couldn't resolve the import and crashed.

2. `loadMovie()` on Win64 was hardcoded to always load the 1080p scene SWF variant (`*1080.swf`), regardless of actual window size. The 1080p scenes import HD skins, so even if you fixed the platform skin you'd still be using HD assets at low resolutions.

4J actually started building a solution for this — they defined `eLibraryFallback_*` enum slots (including `eLibraryFallback_Platform`) and had code to load the non-HD skins into them, but it was gated behind `#ifndef _FINAL_BUILD` (debug only) and the platform skin slot was never actually loaded. So the fallback was incomplete and non-functional.

### New Behavior

The game starts and runs correctly at any resolution on Win64. Above 720p it uses 1080p scene SWFs with HD skins (same as before). At 720p and below it uses 720p scene SWFs with non-HD skins — native assets for the resolution, no downscaling, no blurriness. No crash at any resolution.

### Fix Implementation

**`UIController.h`**: Removed the `_FINAL_BUILD` preprocessor guard around the `eLibraryFallback_*` enum entries so they're available in release builds, not just debug.

**`UIController.cpp` — `loadSkins()`**: Rewrote the Win64 path to load both skin sets at startup:
- `eLibrary_Platform` = `skinHDWin.swf` registered as `platformskinHD.swf`
- `eLibraryFallback_Platform` = `skinWin.swf` registered as `platformskin.swf` (this was the 4J bug — slot existed but was never loaded)
- `eLibrary_*` = all HD skins (`skinHDGraphics.swf`, `skinHD.swf`, etc.)
- `eLibraryFallback_*` = all non-HD skins (`skinGraphics.swf`, `skin.swf`, etc.)

Both sets use distinct registered names so they coexist in the same Iggy session without conflicts.

**`UIScene.cpp` — `loadMovie()`**: On Win64 the scene SWF resolution is now chosen based on actual screen height instead of being hardcoded to 1080p:
- `>720p` loads `*1080.swf` (these import HD skins which import `platformskinHD.swf`)
- `<=720p` loads `*720.swf` (these import non-HD skins which import `platformskin.swf`)

The existing fallback (try 720 if 1080 file is missing) still works as a safety net.


### AI Use Disclosure
Ai was used to write this pr description.

## Related Issues
- Fixes the blurriness side effect from #981