### PR TITLE
Fix crash when loading saved tutorial worlds

### DIFF
--- a/Minecraft.Client/Common/GameRules/GameRuleManager.cpp
+++ b/Minecraft.Client/Common/GameRules/GameRuleManager.cpp
@@ -344,6 +344,7 @@ void GameRuleManager::writeRuleFile(DataOutputStream *dos)
 	// Write schematic files.
 	unordered_map<wstring, ConsoleSchematicFile *> *files;
 	files = getLevelGenerationOptions()->getUnfinishedSchematicFiles();
+	dos->writeInt((int)files->size());
 	for ( auto& it : *files )
 	{
 		const wstring& filename = it.first;
@@ -497,17 +498,36 @@ bool GameRuleManager::readRuleFile(LevelGenerationOptions *lgo, byte *dIn, UINT 
 	}*/
 
 	// subfile
+	// Old saves didn't write a numFiles count before the schematic entries.
+	// Detect this: a real count is small, but a UTF filename prefix reads as a large int.
 	UINT numFiles = contentDis->readInt();
-	for (UINT i = 0; i < numFiles; i++)
+
+	if (lgo->isFromSave() && numFiles > 100)
 	{
-		wstring sFilename = contentDis->readUTF();
-		int length = contentDis->readInt();
-		byteArray ba( length );
+		contentDis->skip(-4);
+		while (true)
+		{
+			int peek = contentDis->readInt();
+			if (peek <= 100) { contentDis->skip(-4); break; }
+			contentDis->skip(-4);
 
-		contentDis->read(ba);
-
-		levelGenerator->loadSchematicFile(sFilename, ba.data, ba.length);
-
+			wstring sFilename = contentDis->readUTF();
+			int length = contentDis->readInt();
+			byteArray ba( length );
+			contentDis->read(ba);
+			levelGenerator->loadSchematicFile(sFilename, ba.data, ba.length);
+		}
+	}
+	else
+	{
+		for (UINT i = 0; i < numFiles; i++)
+		{
+			wstring sFilename = contentDis->readUTF();
+			int length = contentDis->readInt();
+			byteArray ba( length );
+			contentDis->read(ba);
+			levelGenerator->loadSchematicFile(sFilename, ba.data, ba.length);
+		}
 	}
 
 	LEVEL_GEN_ID lgoID = LEVEL_GEN_ID_NULL;


### PR DESCRIPTION
## Description

Fixes the crash when trying to load a saved tutorial world. Players would get the "Unrecognised schematic version!!" error every time they saved a tutorial world and tried to load it back.

## Changes

### Previous Behavior

If you played the tutorial world, saved it, left, and then tried to load that save again, the game would crash with an assertion error in `ConsoleSchematicFile.cpp` line 68.

### Root Cause

When saving the game rules, `writeRuleFile()` wrote all the schematic file data into the stream but forgot to write how many files there are before the actual data. When loading, `readRuleFile()` tries to read that number first. Since it wasn't there, the reader grabbed the wrong bytes, got completely out of sync with the data, and eventually tried to load garbage as a schematic file — which hit the version check and crashed.

### New Behavior

Tutorial saves load fine now. Old saves that were written before this fix are also handled correctly.

### Fix Implementation

Only `GameRuleManager.cpp` was changed:

1. **Writing** (line 347): Added `dos->writeInt((int)files->size())` before the loop that writes schematic files, so the file count is actually in the stream now.

2. **Reading** (lines 500–533): When loading from a save, the code reads the next int and checks if it makes sense as a file count (small number, ≤ 100). If the value is way too large, it's an old save without the count — in that case it rewinds the stream and reads the schematics one by one until it hits the xml-objects section. New saves and DLC files are still read normally.

## Related Issues

- Fixes smartcmd/MinecraftConsoles#58
- Fixes smartcmd/MinecraftConsoles#958