### PR TITLE
Reject duplicate UIDs on login and remove noisy gdraw debug log

### DIFF
--- a/Minecraft.Client/PendingConnection.cpp
+++ b/Minecraft.Client/PendingConnection.cpp
@@ -190,34 +190,11 @@ void PendingConnection::handleLogin(shared_ptr<LoginPacket> packet)
 	}
 	else if (duplicateXuid)
 	{
-		// The old player is still in PlayerList (disconnect hasn't been
-		// processed yet).  Force-close the stale connection so the
-		// reconnecting client isn't rejected.
-		app.DebugPrintf("RECONNECT: Duplicate xuid for name: %ls, forcing old connection closed\n", name.c_str());
-		shared_ptr<ServerPlayer> stalePlayer = server->getPlayers()->getPlayer(loginXuid);
-		if (stalePlayer == nullptr && packet->m_onlineXuid != INVALID_XUID)
-			stalePlayer = server->getPlayers()->getPlayer(packet->m_onlineXuid);
-
-		if (stalePlayer != nullptr && stalePlayer->connection != nullptr)
-		{
-			BYTE oldSmallId = 0;
-			if (stalePlayer->connection->connection != nullptr && stalePlayer->connection->connection->getSocket() != nullptr)
-				oldSmallId = stalePlayer->connection->connection->getSocket()->getSmallId();
-			app.DebugPrintf("RECONNECT: Force-disconnecting old player smallId=%d\n", oldSmallId);
-			stalePlayer->connection->disconnect(DisconnectPacket::eDisconnect_Closed);
-
-			// Queue the old SmallId for recycling so it's not permanently leaked.
-			// PlayerList::tick() will call PushFreeSmallId/ClearSocketForSmallId.
-			if (oldSmallId != 0)
-				server->getPlayers()->queueSmallIdForRecycle(oldSmallId);
-
-			app.DebugPrintf("RECONNECT: Old player force-disconnect complete\n");
-		}
-
-		// Accept the login now that the old entry is removed.
-		app.DebugPrintf("RECONNECT: Calling handleAcceptedLogin for new connection\n");
-		handleAcceptedLogin(packet);
-		app.DebugPrintf("RECONNECT: handleAcceptedLogin complete\n");
+		// Reject the incoming connection — a player with this UID is already
+		// on the server.  Allowing duplicates causes invisible players and
+		// other undefined behaviour.
+		app.DebugPrintf("LOGIN: Rejecting duplicate xuid for name: %ls\n", name.c_str());
+		disconnect(DisconnectPacket::eDisconnect_Banned);
 	}
 #ifdef _WINDOWS64
 	else if (g_bRejectDuplicateNames)

--- a/Minecraft.Client/Windows64/Iggy/gdraw/gdraw_d3d1x_shared.inl
+++ b/Minecraft.Client/Windows64/Iggy/gdraw/gdraw_d3d1x_shared.inl
@@ -998,11 +998,7 @@ static void RADLINK gdraw_SetViewSizeAndWorldScale(S32 w, S32 h, F32 scalex, F32
 {
    static S32 s_lastW = 0, s_lastH = 0;
    static F32 s_lastSx = 0, s_lastSy = 0;
-   if (w != s_lastW || h != s_lastH || scalex != s_lastSx || scaley != s_lastSy) {
-      app.DebugPrintf("[GDRAW] SetViewSize: fw=%d fh=%d scale=%.6f,%.6f frametex=%dx%d vx=%d vy=%d\n",
-         w, h, scalex, scaley, gdraw->frametex_width, gdraw->frametex_height, gdraw->vx, gdraw->vy);
-      s_lastW = w; s_lastH = h; s_lastSx = scalex; s_lastSy = scaley;
-   }
+
    memset(gdraw->frame, 0, sizeof(gdraw->frame));
    gdraw->cur = gdraw->frame;
    gdraw->fw = w;


### PR DESCRIPTION
## Description

Prevents players from joining a server if their UID is already in use by another connected player, fixing invisible players and undefined behaviour caused by duplicate UIDs coexisting in the player list.

## Changes

### Previous Behavior
When a player tried to join a server with a UID matching an already-connected player, the server would force-disconnect the existing player and accept the new connection. This allowed two clients with the same UID to briefly or permanently coexist in the player list, resulting in invisible players and other undefined behaviour.

### Root Cause
PR #767 introduced a reconnect-handling code path in `PendingConnection::handleLogin` that, upon detecting a duplicate UID, would force-kick the stale player and call `handleAcceptedLogin` for the incoming connection. While intended for reconnect scenarios, this unconditionally allowed any duplicate-UID connection through at the cost of evicting the legitimate existing player.

### New Behavior
When a duplicate UID is detected during login, the incoming connection is disconnected. The existing player remains on the server unaffected.

### Fix Implementation
In `PendingConnection::handleLogin`, the `else if (duplicateXuid)` branch previously force-disconnected the stale player, recycled their `smallId`, and called `handleAcceptedLogin` for the new connection. This block has been replaced with a simple `disconnect(DisconnectPacket::eDisconnect_Banned)` call on the incoming connection, consistent with how duplicate names are already handled under `g_bRejectDuplicateNames`.

A leftover per-frame `DebugPrintf` in `gdraw_SetViewSizeAndWorldScale` (introduced during the resolution-fix work in #767) is also removed.

## AI Use Disclosure
No AI was used to write the code in this PR.
AI fully wrote this PR description

## Related Issues
- Related to #767 
- Related to #1012 