### PR TITLE
Splitscreen disconnection fix + mob null pointer checks.

### DIFF
--- a/Minecraft.Client/ClientConnection.cpp
+++ b/Minecraft.Client/ClientConnection.cpp
@@ -2427,6 +2427,7 @@ void ClientConnection::handleAddMob(shared_ptr<AddMobPacket> packet)
 	float xRot = packet->xRot * 360 / 256.0f;
 
 	shared_ptr<LivingEntity> mob = dynamic_pointer_cast<LivingEntity>(EntityIO::newById(packet->type, level));
+	if (mob == nullptr) return;
 	mob->xp = packet->x;
 	mob->yp = packet->y;
 	mob->zp = packet->z;

--- a/Minecraft.Client/Extrax64Stubs.cpp
+++ b/Minecraft.Client/Extrax64Stubs.cpp
@@ -299,11 +299,7 @@ IQNetPlayer* IQNet::GetLocalPlayerByUserIndex(DWORD dwUserIndex)
 		}
 		return nullptr;
 	}
-	// Split-screen pads 1-3: the player is at m_player[dwUserIndex] with isRemote=false
-	if (dwUserIndex < MINECRAFT_NET_MAX_PLAYERS &&
-		!m_player[dwUserIndex].m_isRemote &&
-		Win64_IsActivePlayer(&m_player[dwUserIndex], dwUserIndex))
-		return &m_player[dwUserIndex];
+	// Split-screen pads 1-3 only work in hosting mode
 	return nullptr;
 }
 static bool Win64_IsActivePlayer(IQNetPlayer * p, DWORD index)


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Fixes the instant disconnection that happens after connecting to an online game,
Including a null pointer check for mobs, which prevents the game from crashing.

## Changes

### Previous Behavior
Instant disconnection from a networked game

### Root Cause
The local player is assigned smallId=1 by the server and stored in m_player[1]. The old code returned m_player[1] when checking user index 1 (the split screen slot) making the game think there was a second local player who wasnt signed in (making the client disconnect).

### New Behavior
You wont disconnect, and the game wont crash.

### AI Use Disclosure
No AI needed.