### PR TITLE
Fix floating painting

### DIFF
--- a/Minecraft.World/HangingEntity.cpp
+++ b/Minecraft.World/HangingEntity.cpp
@@ -59,6 +59,9 @@ void HangingEntity::setDir(int dir)
 	float y = yTile + 0.5f;
 	float z = zTile + 0.5f;
 
+	float originalX = x;
+	float originalZ = z;
+
 	float fOffs = 0.5f + 1.0f / 16.0f;
 
 	if (this->GetType() == eTYPE_PAINTING)
@@ -80,6 +83,26 @@ void HangingEntity::setDir(int dir)
 	setPos(x, y, z);
 
 	float ss = -(0.5f / 16.0f);
+
+	//dividing the fOffs by 32 breaks the BB and allow paintings to be placed on a block when they shouldn't
+	//so we need to modify the x and z to set their value as if the fOffs was divided by 16 and not 32
+	if (this->GetType() == eTYPE_PAINTING)
+	{
+		fOffs = 0.5f + 1.0f / 16.0f;
+		if (dir == Direction::NORTH) originalZ -= fOffs;
+		if (dir == Direction::WEST) originalX -= fOffs;
+		if (dir == Direction::SOUTH) originalZ += fOffs;
+		if (dir == Direction::EAST) originalX += fOffs;
+
+		if (dir == Direction::NORTH) originalX -= offs(getWidth());
+		if (dir == Direction::WEST) originalZ += offs(getWidth());
+		if (dir == Direction::SOUTH) originalX += offs(getWidth());
+		if (dir == Direction::EAST) originalZ -= offs(getWidth());
+
+		x = originalX;
+		z = originalZ;
+	}
+
 
 	// 4J Stu - Due to rotations the bb couold be set with a lower bound x/z being higher than the higher bound
 	float x0 = x - w - ss;


### PR DESCRIPTION
## Description
This PR fixes the floating painting describe in the issue #661 

## Changes

### Previous Behavior

Before, there would be a slight gap between a painting, and the block it is placed on.
![before](https://github.com/user-attachments/assets/d6396cfb-ba9b-41c9-9f75-f62c288d3f09)


### Root Cause
The position offset variable "fOffs" in the setDir function in Minecraft.World/HangingEntity.cpp would be the same across all children of HangingEntity, it does not cause issue for the item frame and the leashknot (the only other children of HangingEntity), but for the painting the offset is too big and it causes the visual gap.


### New Behavior
The previous gap is not visible anymore
![after](https://github.com/user-attachments/assets/308dc343-83e9-4fea-8c67-0d8aa14a095a)


### Fix Implementation
the offset is now specific to the painting.
For the painting, it is now set to `0.5f+1.0f/32.0f` instead of `0.5f+1.0f/16.0f`
the new formula is only applied if the type of the item is `eTYPE_PAINTING`


Modifying this value also moves the bounding box of the painting, and it causes an issue where you are able to place a painting on a block where an item frame is already placed on
to fix this issue, the x and z coords are set to the values they currently have, in other words, the x/z coords are recalculated to match the values they would have if fOffs was using its current formula `0.5f+1.0f/16.0f` 

### AI Use Disclosure
no ai was used

## Related Issues
- Fixes #661 
- Related to #661 
