### PR TITLE
Fixed endermans attacking creative players

### DIFF
--- a/Minecraft.World/EnderMan.cpp
+++ b/Minecraft.World/EnderMan.cpp
@@ -410,8 +410,13 @@ bool EnderMan::hurt(DamageSource *source, float damage)
 
 	if ( dynamic_cast<EntityDamageSource *>(source) != nullptr && source->getEntity()->instanceof(eTYPE_PLAYER))
 	{
-		aggroedByPlayer = true;
+		if (!dynamic_pointer_cast<Player>(source->getEntity())->abilities.invulnerable)
+		{
+			aggroedByPlayer = true;
+		}
+		else setCreepy(false);
 	}
+
 
 	if (dynamic_cast<IndirectEntityDamageSource *>(source) != nullptr)
 	{

--- a/Minecraft.World/Monster.cpp
+++ b/Minecraft.World/Monster.cpp
@@ -60,7 +60,14 @@ bool Monster::hurt(DamageSource *source, float dmg)
 
 		if (sourceEntity != shared_from_this()) 
 		{
-			attackTarget = sourceEntity;
+			if (sourceEntity->instanceof(eTYPE_PLAYER))
+			{
+				if (!dynamic_pointer_cast<Player>(sourceEntity)->abilities.invulnerable)
+				{
+					attackTarget = sourceEntity;
+				}
+			}
+			else attackTarget = sourceEntity;
 		}
 		return true;
 	}


### PR DESCRIPTION
Fixed endermans by making a invulnerable check

<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Enderman try to attack creative players that punched them.

## Changes
Added an invulnerability check in monster.cpp

### Previous Behavior
the enderman got angry at creative players

### Root Cause
There was no check for invulnerability.

### New Behavior
There is a check to see if the target player is invulnerable

### Fix Implementation
added a check for invulnerability

### AI Use Disclosure
No AI

## Related Issues
- Fixes #1030
