### PR TITLE
Fix tamed horses despawning when player moves away

### DIFF
--- a/Minecraft.World/EntityHorse.cpp
+++ b/Minecraft.World/EntityHorse.cpp
@@ -515,6 +515,15 @@ bool EntityHorse::canSpawn()
 	return Animal::canSpawn();
 }
 
+bool EntityHorse::removeWhenFarAway()
+{
+	if (isTamed())          return false;
+	if (isSaddled())        return false;
+	if (isLeashed())        return false;
+	if (getArmorType() > 0) return false;
+	return Animal::removeWhenFarAway();
+}
+
 
 shared_ptr<EntityHorse> EntityHorse::getClosestMommy(shared_ptr<Entity> baby, double searchRadius)
 {

--- a/Minecraft.World/EntityHorse.h
+++ b/Minecraft.World/EntityHorse.h
@@ -192,6 +192,7 @@ private:
 public:
 	virtual void containerChanged();
 	virtual bool canSpawn();
+	virtual bool removeWhenFarAway() override;
 
 protected:
 	virtual shared_ptr<EntityHorse> getClosestMommy(shared_ptr<Entity> baby, double searchRadius);


### PR DESCRIPTION
## Description
Fix tamed horses despawning when the player moves away. This addresses a bug reported on the Discord server where multiple users experienced their tamed horses (including ones with saddles and armor) vanishing after leaving the area.

## Changes

### Previous Behavior
Tamed horses with saddles, armor, and leads would despawn when the player moved more than 128 blocks away. This caused players to permanently lose their equipped horses.

### Root Cause
`EntityHorse` did not override `removeWhenFarAway()` and inherited the generic `Animal::removeWhenFarAway()` which only relies on a wander-distance-based despawn protection mechanism (`isDespawnProtected`). This mechanism could fail for horses that wandered far enough, regardless of their tamed/equipped status.

In contrast, `Wolf` and `Ocelot` already had their own `removeWhenFarAway()` overrides that checked `!isTame()`, preventing tamed wolves and cats from despawning. Horses lacked this protection entirely.

### New Behavior
Tamed, saddled, leashed, or armored horses will no longer despawn regardless of distance from the player. Wild horses without any equipment still follow the normal despawn rules.

### Fix Implementation
Added `EntityHorse::removeWhenFarAway()` override that returns `false` (preventing despawn) if any of these conditions are true:
- `isTamed()` - horse has been tamed by a player
- `isSaddled()` - horse has a saddle equipped  
- `isLeashed()` - horse is attached to a lead
- `getArmorType() > 0` - horse has armor equipped

Otherwise falls back to `Animal::removeWhenFarAway()` for wild horses.

## Related Issues
- Fixes a bug reported on the Discord server ("tamed horses are despawning", reported March 5 by multiple users)