### PR TITLE
Fix TNT minecart exploding despite 'TNT Explodes' option being turned…

### DIFF
--- a/Minecraft.World/MinecartTNT.cpp
+++ b/Minecraft.World/MinecartTNT.cpp
@@ -64,28 +64,34 @@ void MinecartTNT::destroy(DamageSource *source)
 
 	double speedSqr = xd * xd + zd * zd;
 
-	if (!source->isExplosion())
+	if (!app.GetGameHostOption(eGameHostOption_TNT) || !source->isExplosion())
 	{
-		spawnAtLocation(std::make_shared<ItemInstance>(Tile::tnt, 1), 0);
+		spawnAtLocation( shared_ptr<ItemInstance>( new ItemInstance(Tile::tnt, 1) ), 0);
 	}
 
-	if (source->isFire() || source->isExplosion() || speedSqr >= 0.01f)
+	if (app.GetGameHostOption(eGameHostOption_TNT))
 	{
-		explode(speedSqr);
+		if (source->isFire() || source->isExplosion() || speedSqr >= 0.01f)
+		{
+			explode(speedSqr);
+		}
 	}
 }
 
 void MinecartTNT::explode(double speedSqr)
 {
+	if (!app.GetGameHostOption(eGameHostOption_TNT))
+	{
+		remove();
+		return;
+	}
+
 	if (!level->isClientSide)
 	{
 		double speed = sqrt(speedSqr);
-		if (speed > 5.0) speed = 5.0;
-		if (app.GetGameHostOption(eGameHostOption_TNT))
-		{
-			level->explode(shared_from_this(), x, y, z, static_cast<float>(4 + random->nextDouble() * 1.5f * speed), true);
-			remove();
-		}
+		if (speed > 5) speed = 5;
+		level->explode(shared_from_this(), x, y, z, (float) (4 + random->nextDouble() * 1.5f * speed), true);
+		remove();
 	}
 }
 
@@ -122,12 +128,15 @@ void MinecartTNT::handleEntityEvent(byte eventId)
 
 void MinecartTNT::primeFuse()
 {
-	fuse = 80;
-
-	if (!level->isClientSide)
+	if (app.GetGameHostOption(eGameHostOption_TNT))
 	{
-		level->broadcastEntityEvent(shared_from_this(), EVENT_PRIME);
-		level->playEntitySound(shared_from_this(), eSoundType_RANDOM_FUSE, 1, 1.0f);
+		fuse = 80;
+
+		if (!level->isClientSide)
+		{
+			level->broadcastEntityEvent(shared_from_this(), EVENT_PRIME);
+			level->playEntitySound(shared_from_this(), eSoundType_RANDOM_FUSE, 1, 1.0f);
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
This is the fix 4J did in TU20 decompiled with IDA

## Changes

### Previous Behavior
Minecart would explode when the option is off

### Root Cause
Design flaw

### New Behavior
Minecart only explodes when the option is on

### Fix Implementation
This was resolved by comparing the pseudocode of TU20 inside IDA with the source code and seeing what logic changes they did (see the images)
<img width="278" height="266" alt="image" src="https://github.com/user-attachments/assets/48e8e37a-5f3b-435b-8525-9f5e36123583" />
<img width="610" height="702" alt="image" src="https://github.com/user-attachments/assets/1b5da71c-87fa-4c86-9c8b-09b7ad8a57ec" />

### AI Use Disclosure
No AI was used.

## Related Issues
I noticed there was already a change for this but the logic and code is not accurate to what 4J did in TU 20 and since I am working on my own version of the December 2014 source with accurate TU changes I decided I would do the change here too.