### PR TITLE
Fix: Prevent clicking disabled checkboxes

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene.cpp
+++ b/Minecraft.Client/Common/UI/UIScene.cpp
@@ -578,9 +578,12 @@ bool UIScene::handleMouseClick(F32 x, F32 y)
 		if (bestCtrl->getControlType() == UIControl::eCheckBox)
 		{
 			UIControl_CheckBox *cb = static_cast<UIControl_CheckBox*>(bestCtrl);
-			bool newState = !cb->IsChecked();
-			cb->setChecked(newState);
-			handleCheckboxToggled((F64)bestId, newState);
+			if (cb->IsEnabled())
+			{
+				bool newState = !cb->IsChecked();
+				cb->setChecked(newState);
+				handleCheckboxToggled((F64)bestId, newState);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Prevents clicking on disabled checkboxes

## Changes

### Previous Behavior
It was still possible to click on disabled checkbox using the mouse

### Root Cause
When clicking on a checkbox it wouldn't check if the checkbox is enabled

### New Behavior
When clicking on a checkbox it now checks if the checkbox is enabled

### Fix Implementation
Added a check for `IsEnabled()` before trying to click on a checkbox

### AI Use Disclosure
No

## Related Issues
- Fixes #1021 
