### PR TITLE
Clamp FOV to prevent screen rotation #1033

### DIFF
--- a/Minecraft.Client/GameRenderer.cpp
+++ b/Minecraft.Client/GameRenderer.cpp
@@ -395,6 +395,7 @@ float GameRenderer::getFov(float a, bool applyEffects)
 		fov += mc->options->fov * 40;
 		fov *= oFov[playerIdx] + (this->fov[playerIdx] - oFov[playerIdx]) * a;
 	}
+	fov = min(fov, 170.0f);
 	if (player->getHealth() <= 0)
 	{
 		float duration = player->deathTime + a;


### PR DESCRIPTION
## Description
Clamp the FOV to a maximum of 170 to prevent screen rotation glitch.

## Changes

### Previous Behavior
Very high FOV values + sprinting could cause the screen to rotate.

### Root Cause
FOV was unbounded which allowed extreme values to basically flip the camera over.

### New Behavior
FOV is no limited to 170.

### Fix Implementation
Added a single line that clamps the value.

### AI Use Disclosure
No.

## Related Issues
- Fixes #1033 

https://github.com/user-attachments/assets/d919b110-d7a3-49f7-b3c9-0af47048ed71