### PR TITLE
Fix fireworks crafting crash

### DIFF
--- a/Minecraft.Client/Common/Network/GameNetworkManager.cpp
+++ b/Minecraft.Client/Common/Network/GameNetworkManager.cpp
@@ -961,7 +961,6 @@ int CGameNetworkManager::ServerThreadProc( void* lpParameter )
 	Entity::useSmallIds();
 	Level::enableLightingCache();
 	Tile::CreateNewThreadStorage();
-	FireworksRecipe::CreateNewThreadStorage();
 
 	MinecraftServer::main(seed, lpParameter); //saveData, app.GetGameHostOption(eGameHostOption_All));
 

--- a/Minecraft.World/FireworksRecipe.cpp
+++ b/Minecraft.World/FireworksRecipe.cpp
@@ -2,47 +2,14 @@
 #include "net.minecraft.world.item.h"
 #include "FireworksRecipe.h"
 
-DWORD FireworksRecipe::tlsIdx = 0;
-FireworksRecipe::ThreadStorage *FireworksRecipe::tlsDefault = nullptr;
-
-FireworksRecipe::ThreadStorage::ThreadStorage()
-{
-	resultItem = nullptr;
-}
-
-void FireworksRecipe::CreateNewThreadStorage()
-{
-	ThreadStorage *tls = new ThreadStorage();
-	if(tlsDefault == nullptr )
-	{
-		tlsIdx = TlsAlloc();
-		tlsDefault = tls;
-	}
-	TlsSetValue(tlsIdx, tls);
-}
-
-void FireworksRecipe::UseDefaultThreadStorage()
-{
-	TlsSetValue(tlsIdx, tlsDefault);
-}
-
-void FireworksRecipe::ReleaseThreadStorage()
-{
-	ThreadStorage *tls = static_cast<ThreadStorage *>(TlsGetValue(tlsIdx));
-	if( tls == tlsDefault ) return;
-
-	delete tls;
-}
-
 void FireworksRecipe::setResultItem(shared_ptr<ItemInstance> item)
 {
-	ThreadStorage *tls = static_cast<ThreadStorage *>(TlsGetValue(tlsIdx));
-	tls->resultItem = item;
+	this->resultItem = item;
 }
 
 FireworksRecipe::FireworksRecipe()
 {
-	//resultItem = nullptr;
+	resultItem = nullptr;
 }
 
 bool FireworksRecipe::matches(shared_ptr<CraftingContainer> craftSlots, Level *level)
@@ -268,9 +235,11 @@ bool FireworksRecipe::matches(shared_ptr<CraftingContainer> craftSlots, Level *l
 
 shared_ptr<ItemInstance> FireworksRecipe::assemble(shared_ptr<CraftingContainer> craftSlots)
 {
-	ThreadStorage *tls = static_cast<ThreadStorage *>(TlsGetValue(tlsIdx));
-	return tls->resultItem->copy();
-	//return resultItem->copy();
+	if (this->resultItem != nullptr)
+	{
+		return this->resultItem->copy();
+	}
+	return nullptr;
 }
 
 int FireworksRecipe::size()
@@ -280,9 +249,7 @@ int FireworksRecipe::size()
 
 const ItemInstance *FireworksRecipe::getResultItem()
 {
-	ThreadStorage *tls = static_cast<ThreadStorage *>(TlsGetValue(tlsIdx));
-	return tls->resultItem.get();
-	//return resultItem.get();
+	return this->resultItem.get();
 }
 
 void FireworksRecipe::updatePossibleRecipes(shared_ptr<CraftingContainer> craftSlots, bool *firework, bool *charge, bool *fade)

--- a/Minecraft.World/FireworksRecipe.h
+++ b/Minecraft.World/FireworksRecipe.h
@@ -5,26 +5,9 @@
 class FireworksRecipe : public Recipy
 {
 private:
-	//shared_ptr<ItemInstance> resultItem;
-
-		// 4J added so we can have separate contexts and rleBuf for different threads
-	class ThreadStorage
-	{
-	public:
-		shared_ptr<ItemInstance> resultItem;
-		ThreadStorage();
-	};
-	static DWORD tlsIdx;
-	static ThreadStorage *tlsDefault;
+	shared_ptr<ItemInstance> resultItem;
 
 	void setResultItem(shared_ptr<ItemInstance> item);
-public:
-	// Each new thread that needs to use Compression will need to call one of the following 2 functions, to either create its own
-	// local storage, or share the default storage already allocated by the main thread
-	static void CreateNewThreadStorage();
-	static void UseDefaultThreadStorage();
-	static void ReleaseThreadStorage();
-
 public:
 	FireworksRecipe();
 


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Fixed a read access violation crash occurring during the fireworks crafting process due to unstable memory management in FireworksRecipe

## Changes

### Previous Behavior
The game would crash when trying to craft fireworks

### Root Cause
The `FireworksRecipe` used Thread Local Storage to temporarily store the `resultItem`. Because the crafting validation (`matches()`) and the actual item generation (`assemble()`) were called from different thread contexts, the TLS would return a nullptr. Attempting to call `copy()` on this null pointer caused a read access violation.

### New Behavior
The game doesn't crash when crafting fireworks

### Fix Implementation
- Removed the TLS architecture and reverted `resultItem` to a private class member
- Reverted `resultItem` to be a private member of the `FireworksRecipe` class.

### AI Use Disclosure
No (I used AI to help debug the crash logs and refine the technical explanation, but the code logic was manually refactored).

## Related Issues
- Fixes #942 
