### PR TITLE
Fix issue where visually the HUD shows you have 0 hearts when you dont

### DIFF
--- a/Minecraft.Client/Common/UI/IUIScene_HUD.cpp
+++ b/Minecraft.Client/Common/UI/IUIScene_HUD.cpp
@@ -195,8 +195,8 @@ void IUIScene_HUD::renderPlayerHealth()
 	// Update health
 	bool blink = pMinecraft->localplayers[iPad]->invulnerableTime / 3 % 2 == 1;
 	if (pMinecraft->localplayers[iPad]->invulnerableTime < 10) blink = false;
-	int currentHealth = (int)ceil(pMinecraft->localplayers[iPad]->getHealth());
-	int oldHealth = (int)ceil(pMinecraft->localplayers[iPad]->lastHealth);
+	int currentHealth = static_cast<int>(ceil(pMinecraft->localplayers[iPad]->getHealth()));
+    int oldHealth = static_cast<int>(ceil(pMinecraft->localplayers[iPad]->lastHealth));
 	bool bHasPoison = pMinecraft->localplayers[iPad]->hasEffect(MobEffect::poison);
 	bool bHasWither = pMinecraft->localplayers[iPad]->hasEffect(MobEffect::wither);
 	AttributeInstance *maxHealthAttribute = pMinecraft->localplayers[iPad]->getAttribute(SharedMonsterAttributes::MAX_HEALTH);


### PR DESCRIPTION
## Description
This is something 4J Studios fixed in TU20 (https://minecraft.fandom.com/wiki/Xbox_360_Edition_TU20)
<img width="693" height="162" alt="image" src="https://github.com/user-attachments/assets/8f096507-c80a-492a-8741-70ecfaed65ca" />

4J also used ceil() in TU20 so this code is the exact same changes they made
<img width="304" height="159" alt="image" src="https://github.com/user-attachments/assets/c6957799-edfa-4875-a4da-eb68be85258e" />

## Changes

### Previous Behavior
HUD would display you have 0 hearts when you have a half of a heart.

### Root Cause
The game was casting the float to a int which truncated the decimal.

### New Behavior
HUD will now show half of a heart instead of none.

### Fix Implementation
Use ceil() to prevent the decimal being truncated.

### AI Use Disclosure
No AI was used.

## Related Issues
- Fixes #753
- Related to #753 
