### PR TITLE
Add SettingDataVersion and Introduce SettingFixer

### DIFF
--- a/Minecraft.Client/Common/App_enums.h
+++ b/Minecraft.Client/Common/App_enums.h
@@ -178,6 +178,9 @@ enum eGameSetting
 	// PSVita
 	eGameSetting_PSVita_NetworkModeAdhoc,
 
+	// Add setting data version
+	eGameSetting_SettingDataVersion,
+
 
 };
 

--- a/Minecraft.Client/Common/App_structs.h
+++ b/Minecraft.Client/Common/App_structs.h
@@ -108,6 +108,8 @@ typedef struct
 			// was 192
 			//unsigned char ucUnused[192-TUTORIAL_PROFILE_STORAGE_BYTES-sizeof(DWORD)-sizeof(char)-sizeof(char)-sizeof(char)-sizeof(char)-sizeof(LONG)-sizeof(LONG)-sizeof(DWORD)];
 			// 4J-PB - don't need to define the padded space, the union with ucReservedSpace will make the sizeof GAME_SETTINGS correct
+
+			unsigned int uiSettingDataVersion;
 		};
 
 		unsigned char ucReservedSpace[192];

--- a/Minecraft.Client/Common/Consoles_App.cpp
+++ b/Minecraft.Client/Common/Consoles_App.cpp
@@ -84,6 +84,8 @@ int CMinecraftApp::s_iHTMLFontSizesA[eHTMLSize_COUNT] =
 #endif
 };
 
+// jvnpr -- update this anytime settingfixer needs to convert old settings to new settings!
+const int currentSettingDataVersion = 1;
 
 CMinecraftApp::CMinecraftApp()
 {
@@ -904,6 +906,8 @@ int CMinecraftApp::SetDefaultOptions(C_4JProfile::PROFILESETTINGS *pSettings,con
 	app.SetGameHostOption(eGameHostOption_NaturalRegeneration, 1 );
 	app.SetGameHostOption(eGameHostOption_DoDaylightCycle, 1 );
 
+	app.SetGameSettings(iPad, eGameSetting_SettingDataVersion, currentSettingDataVersion);
+
 	// 4J-PB - leave these in, or remove from everywhere they are referenced!
 	// Although probably best to leave in unless we split the profile settings into platform specific classes - having different meaning per platform for the same bitmask could get confusing
 	//#ifdef __PS3__
@@ -1362,6 +1366,7 @@ void CMinecraftApp::ApplyGameSettingsChanged(int iPad)
 
 	ActionGameSettings(iPad,eGameSetting_PS3_EULA_Read);
 
+	ActionGameSettings(iPad,eGameSetting_SettingDataVersion);
 }
 
 void CMinecraftApp::ActionGameSettings(int iPad,eGameSetting eVal)
@@ -1596,7 +1601,31 @@ void CMinecraftApp::ActionGameSettings(int iPad,eGameSetting eVal)
 	case eGameSetting_PSVita_NetworkModeAdhoc:
 		//nothing to do here
 		break;
+	case eGameSetting_SettingDataVersion:
+		break;
 	}
+}
+
+void CMinecraftApp::SettingFixer()
+{
+	unsigned int version = ProfileManager.GetPrimaryPad()]->uiSettingDataVersion
+
+	if (GameSettingsA[version != currentSettingDataVersion)
+	{
+		DebugPrintf("[SettingFixer]: Fixing Settings!\n");
+
+		/* ex:
+		if (version < 1) fix v1 setting changes;
+		if (version < 2) fix v2 setting changes;
+		...
+		*/ 
+	}
+	else
+	{
+		DebugPrintf("[SettingFixer]: Nothing to do.\n");
+	}
+
+	GameSettingsA[ProfileManager.GetPrimaryPad()]->uiSettingDataVersion = currentSettingDataVersion;
 }
 
 void CMinecraftApp::SetPlayerSkin(int iPad,const wstring &name)
@@ -2306,7 +2335,14 @@ void CMinecraftApp::SetGameSettings(int iPad,eGameSetting eVal,unsigned char ucV
 			GameSettingsA[iPad]->bSettingsChanged=true;
 		}
 		break;
+	case eGameSetting_SettingDataVersion:
 
+		if (GameSettingsA[iPad]->uiSettingDataVersion != ucVal)
+		{
+			GameSettingsA[iPad]->uiSettingDataVersion = ucVal;
+			ActionGameSettings(iPad, eVal);
+			GameSettingsA[iPad]->bSettingsChanged = true;
+		}
 	}
 }
 
@@ -2441,7 +2477,9 @@ unsigned char CMinecraftApp::GetGameSettings(int iPad,eGameSetting eVal)
 
 	case eGameSetting_PSVita_NetworkModeAdhoc:
 		return (GameSettingsA[iPad]->uiBitmaskValues&GAMESETTING_PSVITANETWORKMODEADHOC)>>17;
-
+	
+	case eGameSetting_SettingDataVersion:
+		return GameSettingsA[iPad]->uiSettingDataVersion;
 	}
 	return 0;
 }

--- a/Minecraft.Client/Common/Consoles_App.cpp
+++ b/Minecraft.Client/Common/Consoles_App.cpp
@@ -794,9 +794,22 @@ static void Win64_LoadSettings(GAME_SETTINGS *gs)
         if (fread(&temp, sizeof(GAME_SETTINGS), 1, f) == 1)
             memcpy(gs, &temp, sizeof(GAME_SETTINGS));
         fclose(f);
+		CMinecraftApp::SetSettingsFileLoaded(true);
     }
 }
 #endif
+
+bool CMinecraftApp::settingFileLoaded = false;
+
+void CMinecraftApp::SetSettingsFileLoaded(bool loaded)
+{
+	settingFileLoaded = loaded;
+}
+
+bool CMinecraftApp::GetSettingsFileLoaded() 
+{ 
+	return settingFileLoaded;
+}
 
 void CMinecraftApp::InitGameSettings()
 {
@@ -1606,26 +1619,36 @@ void CMinecraftApp::ActionGameSettings(int iPad,eGameSetting eVal)
 	}
 }
 
-void CMinecraftApp::SettingFixer()
+void CMinecraftApp::SettingFixer() // jvnpr -- used to convert settings data when necessary
 {
-	unsigned int version = ProfileManager.GetPrimaryPad()]->uiSettingDataVersion
+	int iPad = ProfileManager.GetPrimaryPad();
 
-	if (GameSettingsA[version != currentSettingDataVersion)
+	unsigned int version = GameSettingsA[iPad]->uiSettingDataVersion;
+
+	if (GetSettingsFileLoaded())
 	{
-		DebugPrintf("[SettingFixer]: Fixing Settings!\n");
+		if (version != currentSettingDataVersion)
+		{
+			DebugPrintf("[SettingFixer]: Fixing Settings!\n");
 
-		/* ex:
-		if (version < 1) fix v1 setting changes;
-		if (version < 2) fix v2 setting changes;
-		...
-		*/ 
+			// perform fixing up
+
+			GameSettingsA[iPad]->uiSettingDataVersion = currentSettingDataVersion;
+			GameSettingsA[iPad]->bSettingsChanged = true;
+			CheckGameSettingsChanged(true, iPad);
+
+			DebugPrintf("[SettingFixer]: Settings fixed and saved.\n");
+
+		}
+		else
+		{
+			DebugPrintf("[SettingFixer]: Nothing to do.\n");
+		}
 	}
 	else
 	{
-		DebugPrintf("[SettingFixer]: Nothing to do.\n");
+		DebugPrintf("[SettingFixer]: No settings file found, nothing to do.\n");
 	}
-
-	GameSettingsA[ProfileManager.GetPrimaryPad()]->uiSettingDataVersion = currentSettingDataVersion;
 }
 
 void CMinecraftApp::SetPlayerSkin(int iPad,const wstring &name)

--- a/Minecraft.Client/Common/Consoles_App.h
+++ b/Minecraft.Client/Common/Consoles_App.h
@@ -241,6 +241,7 @@ public:
 	void			SetGameSettings(int iPad,eGameSetting eVal,unsigned char ucVal);
 	unsigned char	GetGameSettings(int iPad,eGameSetting eVal);
 	unsigned char	GetGameSettings(eGameSetting eVal); // for the primary pad
+	void			SettingFixer(); // jvnpr -- used to convert any old settings values to new settings based on uiSettingDataVersion / eGameSetting_SettingDataVersion
 	void			SetPlayerSkin(int iPad,const wstring &name);
 	void			SetPlayerSkin(int iPad,DWORD dwSkinId);
 	void			SetPlayerCape(int iPad,const wstring &name);

--- a/Minecraft.Client/Common/Consoles_App.h
+++ b/Minecraft.Client/Common/Consoles_App.h
@@ -237,11 +237,15 @@ public:
 #endif
 	virtual void	SetRichPresenceContext(int iPad, int contextId) = 0;
 
+	// jvnpr -- SettingFixer & related checks
+	void			SettingFixer(); 
+	static void		SetSettingsFileLoaded(bool loaded);
+	static bool		GetSettingsFileLoaded();
+	static bool		settingFileLoaded; 
 
 	void			SetGameSettings(int iPad,eGameSetting eVal,unsigned char ucVal);
 	unsigned char	GetGameSettings(int iPad,eGameSetting eVal);
 	unsigned char	GetGameSettings(eGameSetting eVal); // for the primary pad
-	void			SettingFixer(); // jvnpr -- used to convert any old settings values to new settings based on uiSettingDataVersion / eGameSetting_SettingDataVersion
 	void			SetPlayerSkin(int iPad,const wstring &name);
 	void			SetPlayerSkin(int iPad,DWORD dwSkinId);
 	void			SetPlayerCape(int iPad,const wstring &name);

--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -1345,6 +1345,7 @@ static Minecraft* InitialiseMinecraftRuntime()
 		return nullptr;
 
 	app.InitGameSettings();
+	app.SettingFixer();
 	app.InitialiseTips();
 
 	return pMinecraft;


### PR DESCRIPTION
## Description
Adds a new game setting to store settings data version, and creates the SettingFixer function to deal with conversions.

## Changes

### Previous Behavior
The game has no way of knowing what build a settings file was created for, or if any conversions need to be performed. 

### New Behavior
Setting files now store a data version. 

### Fix Implementation
Creates a new game setting `eGameSetting_SettingDataVersion` and associated `uiSettingDataVersion` to store the current version of the given settings file. 

Creates the following functions of the class `CMinecraftApp`:
- `SettingFixer()`: Called from `Windows64_Minecraft` at game launch, runs checks to see if a setting file exists, and if one does, what settings data version it has. If the settings data version does not match the `currentSettingDataVersion`, it will perform any necessary conversions to settings data. At the moment, no conversions are implemented. 
- `GetSettingsFileLoaded()` and `SetSettingsFileLoaded()`: Two new helper functions which modify the class variable `static bool settingFileLoaded`

Modifies `Win64_LoadSettings()` to call `SetSettingsFileLoaded(true);` when a settings file has been successfully loaded.

### AI Use Disclosure
No AI was used to author these changes or pull request.

## Related Issues
- Related to #975 
