### PR TITLE
Add smoothBlend functionality to crispBlend for transparent texture mipmaps

### DIFF
--- a/Minecraft.Client/Texture.cpp
+++ b/Minecraft.Client/Texture.cpp
@@ -716,38 +716,47 @@ int Texture::crispBlend(int c0, int c1)
 	int a0 = static_cast<int>(((c0 & 0xff000000) >> 24)) & 0xff;
 	int a1 = static_cast<int>(((c1 & 0xff000000) >> 24)) & 0xff;
 
-	int a = 255;
-	if (a0 + a1 < 255)
+	// continue with crisp blend if it's likely to be an opaque/cutout tile in the atlas
+	if (a0 >= 0xfa || a1 >= 0xfa)
 	{
-		a = 0;
-		a0 = 1;
-		a1 = 1;
+		int a = 255;
+
+		if (a0 + a1 < 255)
+		{
+			a = 0;
+			a0 = 1;
+			a1 = 1;
+		}
+		else if (a0 > a1)
+		{
+			a0 = 255;
+			a1 = 1;
+		}
+		else
+		{
+			a0 = 1;
+			a1 = 255;
+
+		}
+
+		int r0 = ((c0 >> 16) & 0xff) * a0;
+		int g0 = ((c0 >> 8) & 0xff) * a0;
+		int b0 = ((c0) & 0xff) * a0;
+
+		int r1 = ((c1 >> 16) & 0xff) * a1;
+		int g1 = ((c1 >> 8) & 0xff) * a1;
+		int b1 = ((c1) & 0xff) * a1;
+
+		int r = (r0 + r1) / (a0 + a1);
+		int g = (g0 + g1) / (a0 + a1);
+		int b = (b0 + b1) / (a0 + a1);
+
+		return (a << 24) | (r << 16) | (g << 8) | b;
 	}
-	else if (a0 > a1)
+	else // smoothblend if it's transparent
 	{
-		a0 = 255;
-		a1 = 1;
+		return (((a0 + a1) >> 1) << 24) | (((c0 & 0xfefefe) + (c1 & 0xfefefe)) >> 1);
 	}
-	else
-	{
-		a0 = 1;
-		a1 = 255;
-
-	}
-
-	int r0 = ((c0 >> 16) & 0xff) * a0;
-	int g0 = ((c0 >> 8) & 0xff) * a0;
-	int b0 = ((c0) & 0xff) * a0;
-
-	int r1 = ((c1 >> 16) & 0xff) * a1;
-	int g1 = ((c1 >> 8) & 0xff) * a1;
-	int b1 = ((c1) & 0xff) * a1;
-
-	int r = (r0 + r1) / (a0 + a1);
-	int g = (g0 + g1) / (a0 + a1);
-	int b = (b0 + b1) / (a0 + a1);
-
-	return (a << 24) | (r << 16) | (g << 8) | b;
 }
 
 int Texture::getManagerId()


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
Fixes water opacity in default texture pack, making it no longer fully opaque when mipmaps kick in.

## Changes

### Previous Behavior
Water was fading to opaque due to crispBlend destroying texture alpha in mipmaps.

### Root Cause
This seems to be a long standing bug in LCE because they used Notch's crispBlend algorithm to blend texels when calculating mipmaps in realtime, which is intended for cutout textures, not transparent textures. Java edition scrapped the generation of mipmaps for a good while, but in its unused implementation it used smoothBlend to calculate the mips for textures that were supposed to be transparent, i.e. water. This PR just merges their functionality based on the detected alpha value of the pixels.

### New Behavior
Transparent textures such as water keep their transparency in their mipmaps.

### Fix Implementation
If both pixels involved in the blend operation have an alpha value less than 224, they'll be treated as transparent and the smoothBlend algorithm is used to blend the pixels instead, preserving the alpha in the process. If either pixel has an alpha value of 224 or more, crispBlend blends them as normal to avoid losing detail in cutout textures.

### AI Use Disclosure
No AI was used in the making of this code.
