### PR TITLE
Fixed issue with world seeds not saving correctly

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene_LaunchMoreOptionsMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_LaunchMoreOptionsMenu.cpp
@@ -557,8 +557,8 @@ int UIScene_LaunchMoreOptionsMenu::KeyboardCompleteSeedCallback(LPVOID lpParam,b
 		uint16_t pchText[128];
 		ZeroMemory(pchText, 128 * sizeof(uint16_t));
 		Win64_GetKeyboardText(pchText, 128);
-		pClass->m_editSeed.setLabel((wchar_t *)pchText);
-		pClass->m_params->seed = (wchar_t *)pchText;
+		pClass->m_editSeed.setLabel(reinterpret_cast<wchar_t*>(pchText));
+		pClass->m_params->seed = static_cast<wstring>(reinterpret_cast<wchar_t*>(pchText));
 #else
 #ifdef __PSVITA__
 		uint16_t pchText[2048];
@@ -584,7 +584,7 @@ void UIScene_LaunchMoreOptionsMenu::getDirectEditInputs(vector<UIControl_TextInp
 void UIScene_LaunchMoreOptionsMenu::onDirectEditFinished(UIControl_TextInput *input, UIControl_TextInput::EDirectEditResult result)
 {
 	if (result == UIControl_TextInput::eDirectEdit_Confirmed)
-		m_params->seed = input->getEditBuffer();
+		m_params->seed = static_cast<wstring>(input->getEditBuffer());
 }
 #endif
 


### PR DESCRIPTION
## Description
Fix issue where typing in a short seed on world creation doesn't save the seed correctly

## Changes

### Previous Behavior
Typing in a seed on the world creation menu that's less than 8 characters long will result in garbage data being saved as the seed. Happens with controller and KBM. You can see this in-game - if you exit the world options menu and go back in, the seed will show up as boxes □□□. Weirdly, if you type a seed again, it behaves as expected.

### Root Cause
For some reason, assigning `m_params->seed` to the seed text points it to garbage data, when it's 7 characters or less.

### New Behavior
Seed entry behaves as expected.

### Fix Implementation
- Added `static_cast<wstring>` before assignment to `m_params->seed`.
- Also replaced `(wchar_t *)` with `reinterpret_cast<wchar_t*>` in the functions.

### AI Use Disclosure
No AI was used
