### PR TITLE
Fix initial cursor position for in-game UI elements

### DIFF
--- a/Minecraft.Client/Common/UI/IUIScene_AbstractContainerMenu.cpp
+++ b/Minecraft.Client/Common/UI/IUIScene_AbstractContainerMenu.cpp
@@ -16,8 +16,6 @@
 
 #ifdef _WINDOWS64
 #include "..\..\Windows64\KeyboardMouseInput.h"
-
-SavedInventoryCursorPos g_savedInventoryCursorPos = { 0.0f, 0.0f, false };
 #endif
 
 IUIScene_AbstractContainerMenu::IUIScene_AbstractContainerMenu()

--- a/Minecraft.Client/Common/UI/IUIScene_AbstractContainerMenu.h
+++ b/Minecraft.Client/Common/UI/IUIScene_AbstractContainerMenu.h
@@ -1,15 +1,5 @@
 #pragma once
 
-#ifdef _WINDOWS64
-struct SavedInventoryCursorPos
-{
-	float x;
-	float y;
-	bool hasSavedPos;
-};
-extern SavedInventoryCursorPos g_savedInventoryCursorPos;
-#endif
-
 // Uncomment to enable tap input detection to jump 1 slot. Doesn't work particularly well yet, and I feel the system does not need it.
 // Would probably be required if we decide to slow down the pointer movement.
 // 4J Stu - There was a request to be able to navigate the scenes with the dpad, so I have used much of the TAP_DETECTION

--- a/Minecraft.Client/Common/UI/UIScene_AbstractContainerMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_AbstractContainerMenu.cpp
@@ -41,10 +41,6 @@ void UIScene_AbstractContainerMenu::handleDestroy()
 	app.DebugPrintf("UIScene_AbstractContainerMenu::handleDestroy\n");
 
 #ifdef _WINDOWS64
-	g_savedInventoryCursorPos.x = m_pointerPos.x;
-	g_savedInventoryCursorPos.y = m_pointerPos.y;
-	g_savedInventoryCursorPos.hasSavedPos = true;
-
 	g_KBMInput.SetScreenCursorHidden(false);
 	g_KBMInput.SetCursorHiddenForUI(false);
 #endif
@@ -173,16 +169,16 @@ void UIScene_AbstractContainerMenu::PlatformInitialize(int iPad, int startIndex)
 	m_pointerPos = vPointerPos;
 
 #ifdef _WINDOWS64
-	if (g_savedInventoryCursorPos.hasSavedPos)
+	if ((iPad == 0) && g_KBMInput.IsKBMActive())
 	{
-		m_pointerPos.x = g_savedInventoryCursorPos.x;
-		m_pointerPos.y = g_savedInventoryCursorPos.y;
-
-		if (m_pointerPos.x < m_fPointerMinX) m_pointerPos.x = m_fPointerMinX;
-		if (m_pointerPos.x > m_fPointerMaxX) m_pointerPos.x = m_fPointerMaxX;
-		if (m_pointerPos.y < m_fPointerMinY) m_pointerPos.y = m_fPointerMinY;
-		if (m_pointerPos.y > m_fPointerMaxY) m_pointerPos.y = m_fPointerMaxY;
+		m_pointerPos.x = ((m_fPanelMinX + m_fPanelMaxX) * 0.5f) - m_fPointerImageOffsetX;
+		m_pointerPos.y = ((m_fPanelMinY + m_fPanelMaxY) * 0.5f) - m_fPointerImageOffsetY;
 	}
+
+	if (m_pointerPos.x < m_fPointerMinX) m_pointerPos.x = m_fPointerMinX;
+	if (m_pointerPos.x > m_fPointerMaxX) m_pointerPos.x = m_fPointerMaxX;
+	if (m_pointerPos.y < m_fPointerMinY) m_pointerPos.y = m_fPointerMinY;
+	if (m_pointerPos.y > m_fPointerMaxY) m_pointerPos.y = m_fPointerMaxY;
 #endif
 
 	IggyEvent mouseEvent;


### PR DESCRIPTION
## Description
Fixes cursor behavior in UI containers such that the position is now deterministic depending on the type of input being used (controller vs KBM).

The cursor now defaults to the first hotbar slot on controller, and defaults to the center of the UI container on KBM.

## Changes

### Previous Behavior
Cursor position persisted across menu closes/reopens.

### Root Cause
Cursor state was being saved (to `g_savedInventoryCursorPos.x` and `g_savedInventoryCursorPos.y`) when containers were closed and restored, using those cached values on next open.

### New Behavior
Cursor position no longer persists between menu sessions.
- Controller inputs open with the cursor at the first hotbar slot.
- KBM inputs open with the cursor at the center of the menu panel (not forced to a slot).

### Fix Implementation
Removed cursor persistence logic:
- Deleted `SavedInventoryCursorPos` declaration/usage.
- Removed save and restore logic.

Updated `UIScene_AbstractContainerMenu::PlatformInitialize()`:
- Kept existing default pointer to first hotbar slot.
- Added `Windows64` check: `if iPad == 0 && g_KBMInput.IsKBMActive()`, place pointer at panel center.
    - Checking if `iPad ==0` ensures that KBM inputs only affect the primary player's experience on splitscreen, since additional players are guaranteed to be using controllers.

### AI Use Disclosure
No AI was used to implement these changes.

## Related Issues
- Fixes Discord Thread 1480743335579877517
