### PR TITLE
Fix wither boss bug

### DIFF
--- a/Minecraft.Client/PSVita/Builds/CopyDataFiles.cmd
+++ b/Minecraft.Client/PSVita/Builds/CopyDataFiles.cmd
@@ -1,0 +1,78 @@
+
+:: Copies all files for PS Vita Minecraft
+
+:: PARAM
+:: %1 - Target Dir
+:: %2 - Territory
+
+::Set back level
+pushd .
+cd ..\..\
+
+::Remove Directories
+if exist %1\%2 rmdir /S /Q %1\%2
+
+:: Create directories
+if not exist %1\%2 mkdir %1\%2
+
+::Copying app files [images etc.]
+xcopy /I /Y /S "PSVita\app" "%1\%2\app"
+
+::Correct Param.sfo depending on territory
+copy "PSVita\app\Region\%2\param.sfo" "%1\%2\app\sce_sys\param.sfo"
+
+::Copy correct livearea xml depending on territory
+::Trial
+copy "PSVita\app\Region\%2\template-trial.xml" "%1\%2\app\sce_sys\livearea\contents\template.xml"
+::Full
+copy "PSVita\app\Region\%2\template.xml" "%1\%2\app\sce_sys\retail\livearea\contents\template.xml"
+
+::Remove Region folder
+rmdir /S /Q %1\%2\app\Region
+
+::Copying Game Files
+::Common - Media
+if not exist %1\%2\app\Common\Media mkdir %1\%2\app\Common\Media
+xcopy /I /Y /S Common\Media\font %1\%2\app\Common\Media\font
+xcopy /I /Y Common\Media\MediaPSVita.arc %1\%2\app\Common\Media\
+xcopy /I /Y /S Common\res %1\%2\app\Common\res
+::Music
+xcopy /I /Y /S music %1\%2\app\music
+::Sounds
+xcopy /I /Y /S PSVita\Sound %1\%2\app\PSVita\Sound
+::Product codes
+copy ..\PsVitaProductCodes\%2\PSVitaProductCodes.bin %1\%2\app\PSVita\PSVitaProductCodes.bin
+::Invite image
+copy PSVita\session_image.png %1\%2\app\PSVita\session_image.png
+::DLC
+xcopy /I /Y /S PSVita\DLC %1\%2\app\PSVita\DLC
+::Trophy file
+mkdir %1\%2\app\sce_sys\trophy\NPWR06859_00\
+copy  PSVita\GameConfig\Minecraft_signed.trp %1\%2\app\sce_sys\trophy\NPWR06859_00\TROPHY.TRP
+
+:: Manual
+if exist PSVita\app\Region\%2\manual xcopy /I /Y /S PSVita\app\Region\%2\manual %1\%2\app\sce_sys\manual
+
+
+::Removing files
+rmdir /S /Q %1\%2\app\Common\res\TitleUpdate\GameRules\BuildOnly
+rmdir /S /Q %1\%2\app\Common\res\achievement
+rmdir /S /Q %1\%2\app\Common\res\1_2_2\achievement
+
+::Remove Microsoft fonts
+del /F /S /Q %1\%2\app\Common\Media\font\KOR\BOKMSD.ttf
+del /F /S /Q %1\%2\app\Common\Media\font\RU\SpaceMace.ttf
+del /F /S /Q %1\%2\app\Common\Media\font\JPN\DFGMaruGothic-Md.ttf
+del /F /S /Q %1\%2\app\Common\Media\font\CHT\DFHeiMedium-B5.ttf
+
+:: Creating EBOOT.bin
+"%SCE_PSP2_SDK_DIR%\host_tools\build\bin\psp2bin" -i ..\PSVita_ContentPackage\Minecraft.Client.self --strip-all -o %1\%2\app\eboot.bin
+copy ..\PSVita_ContentPackage\Minecraft.Client.self %1\%2\%2.self
+
+::Move the gp4p file
+move /Y %1\%2\app\Minecraft.Client_%2.gp4p %1\%2\Minecraft.Client_%2.gp4p
+
+::End dir
+popd
+
+echo Copied Files for %1 Build


### PR DESCRIPTION

## Description
<!-- Briefly describe the changes this PR introduces. -->
This pullRequest resolves a read access violation crashing the game that occurs when respawning the Wither boss in the End after kill the dragoon.  
## Changes

### Previous Behavior

When respawning the Wither boss in the End, the game would crash with a read access violation exception if a `MultiEntityMobPart` received damage.  

### Root Cause

In `MultiEntityMobPart.cpp` at line 36, the code calls `parentMob.lock()->hurt(...)`. When respawning the Wither in this specific scenario, `parentMob.lock()` returns a `nullptr`, causing a crash when the code attempts to immediately dereference it.

### New Behavior

The game no longer crashes when respawning the Wither boss in the End. The damage event is handled safely even if the parent mob pointer is momentarily invalid.

### Fix Implementation
Added a if statement to check for the `std::shared_ptr` returned by `parentMob.lock()` in `MultiEntityMobPart::hurt()` if will give Exception it will avoid that with return false 

### AI Use Disclosure
No using for AI

## Related Issues
- Fixes #1096
- Related to #1096
<img width="1601" height="744" alt="لقطة شاشة 2026-03-11 014718" src="https://github.com/user-attachments/assets/b4b5f099-e77a-4069-9111-5b4139ea724d" />
