### PR TITLE
Fix FOV Slider + Viewmodel

### DIFF
--- a/Minecraft.Client/Common/App_enums.h
+++ b/Minecraft.Client/Common/App_enums.h
@@ -178,6 +178,9 @@ enum eGameSetting
 	// PSVita
 	eGameSetting_PSVita_NetworkModeAdhoc,
 
+	// Add setting data version
+	eGameSetting_SettingDataVersion,
+
 
 };
 

--- a/Minecraft.Client/Common/App_structs.h
+++ b/Minecraft.Client/Common/App_structs.h
@@ -108,6 +108,8 @@ typedef struct
 			// was 192
 			//unsigned char ucUnused[192-TUTORIAL_PROFILE_STORAGE_BYTES-sizeof(DWORD)-sizeof(char)-sizeof(char)-sizeof(char)-sizeof(char)-sizeof(LONG)-sizeof(LONG)-sizeof(DWORD)];
 			// 4J-PB - don't need to define the padded space, the union with ucReservedSpace will make the sizeof GAME_SETTINGS correct
+
+			unsigned int uiSettingDataVersion;
 		};
 
 		unsigned char ucReservedSpace[192];

--- a/Minecraft.Client/Common/Consoles_App.cpp
+++ b/Minecraft.Client/Common/Consoles_App.cpp
@@ -84,6 +84,8 @@ int CMinecraftApp::s_iHTMLFontSizesA[eHTMLSize_COUNT] =
 #endif
 };
 
+// jvnpr -- update this anytime settingfixer needs to convert old settings to new settings!
+const int currentSettingDataVersion = 1;
 
 CMinecraftApp::CMinecraftApp()
 {
@@ -904,6 +906,8 @@ int CMinecraftApp::SetDefaultOptions(C_4JProfile::PROFILESETTINGS *pSettings,con
 	app.SetGameHostOption(eGameHostOption_NaturalRegeneration, 1 );
 	app.SetGameHostOption(eGameHostOption_DoDaylightCycle, 1 );
 
+	app.SetGameSettings(iPad, eGameSetting_SettingDataVersion, currentSettingDataVersion);
+
 	// 4J-PB - leave these in, or remove from everywhere they are referenced!
 	// Although probably best to leave in unless we split the profile settings into platform specific classes - having different meaning per platform for the same bitmask could get confusing
 	//#ifdef __PS3__
@@ -1362,6 +1366,7 @@ void CMinecraftApp::ApplyGameSettingsChanged(int iPad)
 
 	ActionGameSettings(iPad,eGameSetting_PS3_EULA_Read);
 
+	ActionGameSettings(iPad,eGameSetting_SettingDataVersion);
 }
 
 void CMinecraftApp::ActionGameSettings(int iPad,eGameSetting eVal)
@@ -1596,7 +1601,31 @@ void CMinecraftApp::ActionGameSettings(int iPad,eGameSetting eVal)
 	case eGameSetting_PSVita_NetworkModeAdhoc:
 		//nothing to do here
 		break;
+	case eGameSetting_SettingDataVersion:
+		break;
 	}
+}
+
+void CMinecraftApp::SettingFixer()
+{
+	unsigned int version = ProfileManager.GetPrimaryPad()]->uiSettingDataVersion
+
+	if (GameSettingsA[version != currentSettingDataVersion)
+	{
+		DebugPrintf("[SettingFixer]: Fixing Settings!\n");
+
+		/* ex:
+		if (version < 1) fix v1 setting changes;
+		if (version < 2) fix v2 setting changes;
+		...
+		*/ 
+	}
+	else
+	{
+		DebugPrintf("[SettingFixer]: Nothing to do.\n");
+	}
+
+	GameSettingsA[ProfileManager.GetPrimaryPad()]->uiSettingDataVersion = currentSettingDataVersion;
 }
 
 void CMinecraftApp::SetPlayerSkin(int iPad,const wstring &name)
@@ -2306,7 +2335,14 @@ void CMinecraftApp::SetGameSettings(int iPad,eGameSetting eVal,unsigned char ucV
 			GameSettingsA[iPad]->bSettingsChanged=true;
 		}
 		break;
+	case eGameSetting_SettingDataVersion:
 
+		if (GameSettingsA[iPad]->uiSettingDataVersion != ucVal)
+		{
+			GameSettingsA[iPad]->uiSettingDataVersion = ucVal;
+			ActionGameSettings(iPad, eVal);
+			GameSettingsA[iPad]->bSettingsChanged = true;
+		}
 	}
 }
 
@@ -2441,7 +2477,9 @@ unsigned char CMinecraftApp::GetGameSettings(int iPad,eGameSetting eVal)
 
 	case eGameSetting_PSVita_NetworkModeAdhoc:
 		return (GameSettingsA[iPad]->uiBitmaskValues&GAMESETTING_PSVITANETWORKMODEADHOC)>>17;
-
+	
+	case eGameSetting_SettingDataVersion:
+		return GameSettingsA[iPad]->uiSettingDataVersion;
 	}
 	return 0;
 }

--- a/Minecraft.Client/Common/Consoles_App.cpp
+++ b/Minecraft.Client/Common/Consoles_App.cpp
@@ -852,7 +852,7 @@ int CMinecraftApp::SetDefaultOptions(C_4JProfile::PROFILESETTINGS *pSettings,con
 	SetGameSettings(iPad,eGameSetting_SoundFXVolume,DEFAULT_VOLUME_LEVEL);
 	SetGameSettings(iPad,eGameSetting_RenderDistance,16);
 	SetGameSettings(iPad,eGameSetting_Gamma,50);
-	SetGameSettings(iPad,eGameSetting_FOV,0);
+	SetGameSettings(iPad,eGameSetting_FOV,40); //jvnpr -- 40 here is an FOV of 70 (FOV = eGameSetting_FOV - 30)
 
 	// 4J-PB - Don't reset the difficult level if we're in-game
 	if(Minecraft::GetInstance()->level==nullptr)
@@ -1424,9 +1424,8 @@ void CMinecraftApp::ActionGameSettings(int iPad,eGameSetting eVal)
 	case eGameSetting_FOV:
 		if(iPad==ProfileManager.GetPrimaryPad())
 		{
-			float fovDeg = 70.0f + (float)GameSettingsA[iPad]->ucFov * 40.0f / 100.0f;
-			pMinecraft->gameRenderer->SetFovVal(fovDeg);
-			pMinecraft->options->set(Options::Option::FOV, (float)GameSettingsA[iPad]->ucFov / 100.0f);
+			float v = static_cast<float>(GameSettingsA[iPad]->ucFov);
+			pMinecraft->options->fov = (v / 40.0f) - 1; // map to range between -1 and 1.
 		}
 		break;
 	case eGameSetting_Difficulty:		

--- a/Minecraft.Client/Common/Consoles_App.cpp
+++ b/Minecraft.Client/Common/Consoles_App.cpp
@@ -794,9 +794,22 @@ static void Win64_LoadSettings(GAME_SETTINGS *gs)
         if (fread(&temp, sizeof(GAME_SETTINGS), 1, f) == 1)
             memcpy(gs, &temp, sizeof(GAME_SETTINGS));
         fclose(f);
+		CMinecraftApp::SetSettingsFileLoaded(true);
     }
 }
 #endif
+
+bool CMinecraftApp::settingFileLoaded = false;
+
+void CMinecraftApp::SetSettingsFileLoaded(bool loaded)
+{
+	settingFileLoaded = loaded;
+}
+
+bool CMinecraftApp::GetSettingsFileLoaded() 
+{ 
+	return settingFileLoaded;
+}
 
 void CMinecraftApp::InitGameSettings()
 {
@@ -1606,26 +1619,36 @@ void CMinecraftApp::ActionGameSettings(int iPad,eGameSetting eVal)
 	}
 }
 
-void CMinecraftApp::SettingFixer()
+void CMinecraftApp::SettingFixer() // jvnpr -- used to convert settings data when necessary
 {
-	unsigned int version = ProfileManager.GetPrimaryPad()]->uiSettingDataVersion
+	int iPad = ProfileManager.GetPrimaryPad();
 
-	if (GameSettingsA[version != currentSettingDataVersion)
+	unsigned int version = GameSettingsA[iPad]->uiSettingDataVersion;
+
+	if (GetSettingsFileLoaded())
 	{
-		DebugPrintf("[SettingFixer]: Fixing Settings!\n");
+		if (version != currentSettingDataVersion)
+		{
+			DebugPrintf("[SettingFixer]: Fixing Settings!\n");
 
-		/* ex:
-		if (version < 1) fix v1 setting changes;
-		if (version < 2) fix v2 setting changes;
-		...
-		*/ 
+			// perform fixing up
+
+			GameSettingsA[iPad]->uiSettingDataVersion = currentSettingDataVersion;
+			GameSettingsA[iPad]->bSettingsChanged = true;
+			CheckGameSettingsChanged(true, iPad);
+
+			DebugPrintf("[SettingFixer]: Settings fixed and saved.\n");
+
+		}
+		else
+		{
+			DebugPrintf("[SettingFixer]: Nothing to do.\n");
+		}
 	}
 	else
 	{
-		DebugPrintf("[SettingFixer]: Nothing to do.\n");
+		DebugPrintf("[SettingFixer]: No settings file found, nothing to do.\n");
 	}
-
-	GameSettingsA[ProfileManager.GetPrimaryPad()]->uiSettingDataVersion = currentSettingDataVersion;
 }
 
 void CMinecraftApp::SetPlayerSkin(int iPad,const wstring &name)

--- a/Minecraft.Client/Common/Consoles_App.cpp
+++ b/Minecraft.Client/Common/Consoles_App.cpp
@@ -85,7 +85,7 @@ int CMinecraftApp::s_iHTMLFontSizesA[eHTMLSize_COUNT] =
 };
 
 // jvnpr -- update this anytime settingfixer needs to convert old settings to new settings!
-const int currentSettingDataVersion = 1;
+const int currentSettingDataVersion = 2;
 
 CMinecraftApp::CMinecraftApp()
 {
@@ -1630,7 +1630,18 @@ void CMinecraftApp::SettingFixer() // jvnpr -- used to convert settings data whe
 		{
 			DebugPrintf("[SettingFixer]: Fixing Settings!\n");
 
-			// perform fixing up
+			
+			if (version < 2) { // FOV changes
+				float newFov = GetGameSettings(iPad,eGameSetting_FOV) * 40.0f / 100.0f; // convert old setting of 0-100 to a new range of 0-40
+				if (newFov > 20) newFov = 20; // FOV setting of 90 with old system is equivalent to an FOV of 110 (maximum) with new system.
+				newFov *= 2; // map range of 0-20 to 0-40 so we can convert to a new equivalent FOV
+				newFov += 40; // offset so that our new FOV is within the range of 40-80. (we store as 0-80 instead of 30-110)
+
+				Minecraft* pMinecraft = Minecraft::GetInstance();
+				pMinecraft->options->fov = (newFov / 40.0f) - 1; // convert 0-80 to range of -1 to 1
+
+				SetGameSettings(iPad, eGameSetting_FOV, newFov);
+			}
 
 			GameSettingsA[iPad]->uiSettingDataVersion = currentSettingDataVersion;
 			GameSettingsA[iPad]->bSettingsChanged = true;

--- a/Minecraft.Client/Common/Consoles_App.h
+++ b/Minecraft.Client/Common/Consoles_App.h
@@ -241,6 +241,7 @@ public:
 	void			SetGameSettings(int iPad,eGameSetting eVal,unsigned char ucVal);
 	unsigned char	GetGameSettings(int iPad,eGameSetting eVal);
 	unsigned char	GetGameSettings(eGameSetting eVal); // for the primary pad
+	void			SettingFixer(); // jvnpr -- used to convert any old settings values to new settings based on uiSettingDataVersion / eGameSetting_SettingDataVersion
 	void			SetPlayerSkin(int iPad,const wstring &name);
 	void			SetPlayerSkin(int iPad,DWORD dwSkinId);
 	void			SetPlayerCape(int iPad,const wstring &name);

--- a/Minecraft.Client/Common/Consoles_App.h
+++ b/Minecraft.Client/Common/Consoles_App.h
@@ -237,11 +237,15 @@ public:
 #endif
 	virtual void	SetRichPresenceContext(int iPad, int contextId) = 0;
 
+	// jvnpr -- SettingFixer & related checks
+	void			SettingFixer(); 
+	static void		SetSettingsFileLoaded(bool loaded);
+	static bool		GetSettingsFileLoaded();
+	static bool		settingFileLoaded; 
 
 	void			SetGameSettings(int iPad,eGameSetting eVal,unsigned char ucVal);
 	unsigned char	GetGameSettings(int iPad,eGameSetting eVal);
 	unsigned char	GetGameSettings(eGameSetting eVal); // for the primary pad
-	void			SettingFixer(); // jvnpr -- used to convert any old settings values to new settings based on uiSettingDataVersion / eGameSetting_SettingDataVersion
 	void			SetPlayerSkin(int iPad,const wstring &name);
 	void			SetPlayerSkin(int iPad,DWORD dwSkinId);
 	void			SetPlayerCape(int iPad,const wstring &name);

--- a/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
@@ -25,7 +25,7 @@ UIScene_DebugOverlay::UIScene_DebugOverlay(int iPad, void *initData, UILayer *pa
 	const Minecraft *pMinecraft = Minecraft::GetInstance();
 	WCHAR TempString[256];
 	const int displayFOV = 30 + app.GetGameSettings(m_iPad,eGameSetting_FOV);
-	swprintf(TempString, 256, L"Set fov (%d)", displayFov);
+	swprintf(TempString, 256, L"Set fov (%d)", displayFOV);
 	m_sliderFov.init(TempString,eControl_FOV,0,80,app.GetGameSettings(m_iPad,eGameSetting_FOV));
 
 	const float currentTime = pMinecraft->level->getLevelData()->getGameTime() % 24000;

--- a/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
@@ -6,6 +6,7 @@
 #include "..\..\Minecraft.h"
 #include "..\..\MinecraftServer.h"
 #include "..\..\GameRenderer.h"
+#include "..\..\Options.h"
 #include "..\..\MultiPlayerLevel.h"
 #include "ClientConnection.h"
 #include "MultiPlayerLocalPlayer.h"
@@ -22,15 +23,14 @@ UIScene_DebugOverlay::UIScene_DebugOverlay(int iPad, void *initData, UILayer *pa
 	initialiseMovie();
 
 	const Minecraft *pMinecraft = Minecraft::GetInstance();
-	WCHAR tempString[256];
-	const int fovSliderVal = app.GetGameSettings(m_iPad, eGameSetting_FOV);
-	const int fovDeg = 70 + fovSliderVal * 40 / 100;
-	swprintf( tempString, 256, L"Set fov (%d)", fovDeg);
-	m_sliderFov.init(tempString,eControl_FOV,0,100,fovSliderVal);
+	WCHAR TempString[256];
+	const int displayFOV = 30 + app.GetGameSettings(m_iPad,eGameSetting_FOV);
+	swprintf(TempString, 256, L"Set fov (%d)", fovDeg);
+	m_sliderFov.init(TempString,eControl_FOV,0,80,app.GetGameSettings(m_iPad,eGameSetting_FOV);
 
 	const float currentTime = pMinecraft->level->getLevelData()->getGameTime() % 24000;
-	swprintf( tempString, 256, L"Set time (unsafe) (%d)", static_cast<int>(currentTime));
-	m_sliderTime.init(tempString,eControl_Time,0,240,currentTime/100);
+	swprintf(TempString, 256, L"Set time (unsafe) (%d)", static_cast<int>(currentTime));
+	m_sliderTime.init(TempString,eControl_Time,0,240,currentTime/100);
 
 	m_buttonRain.init(L"Toggle Rain",eControl_Rain);
 	m_buttonThunder.init(L"Toggle Thunder",eControl_Thunder);
@@ -274,17 +274,17 @@ void UIScene_DebugOverlay::handleSliderMove(F64 sliderId, F64 currentValue)
 		break;
 	case eControl_FOV:
 		{
-			Minecraft *pMinecraft = Minecraft::GetInstance();
 			int v = static_cast<int>(currentValue);
 			if (v < 0) v = 0;
-			if (v > 100) v = 100;
-			int fovDeg = 70 + v * 40 / 100;
-			pMinecraft->gameRenderer->SetFovVal(static_cast<float>(fovDeg));
-			app.SetGameSettings(m_iPad, eGameSetting_FOV, v);
+			if (v > 80) v = 80;
+			int displayFOV = v + 30; // convert 0-80 to 30-110
 
-			WCHAR tempString[256];
-			swprintf( tempString, 256, L"Set fov (%d)", fovDeg);
-			m_sliderFov.setLabel(tempString);
+			Minecraft* pMinecraft = Minecraft::GetInstance();
+			pMinecraft->options->fov = (v / 40.0f) - 1;
+
+			WCHAR TempString[256];
+			swprintf((WCHAR*)TempString, 256, L"FOV: %d", displayFOV);
+			m_sliderFov.setLabel(TempString);
 		}
 		break;
 	};

--- a/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
@@ -25,8 +25,8 @@ UIScene_DebugOverlay::UIScene_DebugOverlay(int iPad, void *initData, UILayer *pa
 	const Minecraft *pMinecraft = Minecraft::GetInstance();
 	WCHAR TempString[256];
 	const int displayFOV = 30 + app.GetGameSettings(m_iPad,eGameSetting_FOV);
-	swprintf(TempString, 256, L"Set fov (%d)", fovDeg);
-	m_sliderFov.init(TempString,eControl_FOV,0,80,app.GetGameSettings(m_iPad,eGameSetting_FOV);
+	swprintf(TempString, 256, L"Set fov (%d)", displayFov);
+	m_sliderFov.init(TempString,eControl_FOV,0,80,app.GetGameSettings(m_iPad,eGameSetting_FOV));
 
 	const float currentTime = pMinecraft->level->getLevelData()->getGameTime() % 24000;
 	swprintf(TempString, 256, L"Set time (unsafe) (%d)", static_cast<int>(currentTime));

--- a/Minecraft.Client/Common/UI/UIScene_SettingsGraphicsMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_SettingsGraphicsMenu.cpp
@@ -5,34 +5,6 @@
 #include "..\..\Options.h"
 #include "..\..\GameRenderer.h"
 
-namespace
-{
-    constexpr int FOV_MIN = 70;
-    constexpr int FOV_MAX = 110;
-    constexpr int FOV_SLIDER_MAX = 100;
-
-	int ClampFov(int value)
-	{
-		if (value < FOV_MIN) return FOV_MIN;
-		if (value > FOV_MAX) return FOV_MAX;
-		return value;
-	}
-
-    [[maybe_unused]]
-    int FovToSliderValue(float fov)
-	{
-		const int clampedFov = ClampFov(static_cast<int>(fov + 0.5f));
-		return ((clampedFov - FOV_MIN) * FOV_SLIDER_MAX) / (FOV_MAX - FOV_MIN);
-	}
-
-	int sliderValueToFov(int sliderValue)
-	{
-		if (sliderValue < 0) sliderValue = 0;
-		if (sliderValue > FOV_SLIDER_MAX) sliderValue = FOV_SLIDER_MAX;
-		return FOV_MIN + ((sliderValue * (FOV_MAX - FOV_MIN)) / FOV_SLIDER_MAX);
-	}
-}
-
 int UIScene_SettingsGraphicsMenu::LevelToDistance(int level)
 {
 	static const int table[6] = {2,4,8,16,32,64};
@@ -72,11 +44,11 @@ UIScene_SettingsGraphicsMenu::UIScene_SettingsGraphicsMenu(int iPad, void *initD
 	swprintf( TempString, 256, L"%ls: %d%%", app.GetString( IDS_SLIDER_GAMMA ),app.GetGameSettings(m_iPad,eGameSetting_Gamma));	
 	m_sliderGamma.init(TempString,eControl_Gamma,0,100,app.GetGameSettings(m_iPad,eGameSetting_Gamma));
 
-    const int initialFovSlider = app.GetGameSettings(m_iPad, eGameSetting_FOV);
-	const int initialFovDeg = sliderValueToFov(initialFovSlider);
-	swprintf(TempString, 256, L"FOV: %d", initialFovDeg);
-	m_sliderFOV.init(TempString, eControl_FOV, 0, FOV_SLIDER_MAX, initialFovSlider);
-	
+	// if FOV = 70, display "Default" instead; otherwise display true value. 
+	if (static_cast<int>(30.0f + app.GetGameSettings(m_iPad, eGameSetting_FOV)) == 70) swprintf((WCHAR*)TempString, 256, L"FOV: Default");
+	else swprintf((WCHAR*)TempString, 256, L"FOV: %d", static_cast<int>(30.0f + app.GetGameSettings(m_iPad, eGameSetting_FOV)));
+	m_sliderFOV.init(TempString, eControl_FOV, 0, 80, app.GetGameSettings(m_iPad, eGameSetting_FOV));
+
 	swprintf( TempString, 256, L"%ls: %d%%", app.GetString( IDS_SLIDER_INTERFACEOPACITY ),app.GetGameSettings(m_iPad,eGameSetting_InterfaceOpacity));	
 	m_sliderInterfaceOpacity.init(TempString,eControl_InterfaceOpacity,0,100,app.GetGameSettings(m_iPad,eGameSetting_InterfaceOpacity));
 
@@ -217,14 +189,25 @@ void UIScene_SettingsGraphicsMenu::handleSliderMove(F64 sliderId, F64 currentVal
 
 	case eControl_FOV:
 		{
-			m_sliderFOV.handleSliderMove(value);
-			const Minecraft* pMinecraft = Minecraft::GetInstance();
-			const int fovValue = sliderValueToFov(value);
-			pMinecraft->gameRenderer->SetFovVal(static_cast<float>(fovValue));
-			app.SetGameSettings(m_iPad, eGameSetting_FOV, value);
-			WCHAR tempString[256];
-			swprintf(tempString, 256, L"FOV: %d", fovValue);
-			m_sliderFOV.setLabel(tempString);
+			// jvnpr -- code in Consoles_App.cpp should reflect the same calculations as here so that controller and mouse inputs work the same.
+			int v = static_cast<int>(currentValue);
+			m_sliderFOV.handleSliderMove(v);
+
+			if (v < 0) v = 0;
+			if (v > 80) v = 80;
+			int displayFOV = v + 30;
+
+			Minecraft* pMinecraft = Minecraft::GetInstance();
+			pMinecraft->options->fov = (v / 40.0f) - 1; // use FOV option framework instead of modifying hardcoded gameRenderer value
+
+			WCHAR TempString[256];
+
+			if (displayFOV == 70) swprintf((WCHAR*)TempString, 256, L"FOV: Default");
+			else swprintf((WCHAR*)TempString, 256, L"FOV: %d", static_cast<int>(30.0f + app.GetGameSettings(m_iPad, eGameSetting_FOV)));
+			m_sliderFOV.setLabel(TempString);
+
+			app.SetGameSettings(m_iPad, eGameSetting_FOV, v);
+
 		}
 		break;
 

--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -1345,6 +1345,7 @@ static Minecraft* InitialiseMinecraftRuntime()
 		return nullptr;
 
 	app.InitGameSettings();
+	app.SettingFixer();
 	app.InitialiseTips();
 
 	return pMinecraft;


### PR DESCRIPTION
# [!] This PR is dependent on #1097 

## Description
Change the FOV slider to use the existing fov option system instead of modifying the base FOV value in `gameRenderer`. 
Expands the slider range from 70-110 to 30-110, and makes slider values 1:1 with ticks. 

## Changes

### Previous Behavior
The FOV slider values are not accurate compared to other platforms and causes issues when high FOV values are used. FOV setting also affects the hand viewmodel.

<img width="400" height="235" alt="lcenightlybuild110" src="https://github.com/user-attachments/assets/d987d2f6-42ec-4c46-9bb1-883f433f87a9" /> <img width="400" height="235" alt="java110" src="https://github.com/user-attachments/assets/007f3937-dea6-494e-8ef6-4c20b9745e77" />

### Root Cause
Current implementation uses the `gameRenderer` function `SetFovVal()`, which changes the base FOV value used to render the game. `gameRenderer` uses this base FOV for both the screen and hand viewmodel.

The slider was implemented by creating a slider with a range of 0-100, then mapping that range to 70-110. This means the slider must be moved multiple ticks to change the value by 1. 

### New Behavior
Switched to using the method `Minecraft::GetInstance()->options->fov` to adjust FOV.
Hand viewmodel no longer is affected by FOV setting.
Slider values are now 1:1 with ticks. 

<img width="400" height="235" alt="fovsliderfix110" src="https://github.com/user-attachments/assets/49ec7553-d5f0-4573-8ded-19ceec0ad44a" /><img width="400" height="235" alt="java110" src="https://github.com/user-attachments/assets/0ff7ae3d-f764-4bea-a64b-b52d3bb5b3d9" />

<img width="400" height="235" alt="fovsliderfix30" src="https://github.com/user-attachments/assets/9d118b85-23ff-4e17-9886-9b0d7d66e16c" /><img width="400" height="235" alt="java30" src="https://github.com/user-attachments/assets/039a9bd1-614b-4b1c-96da-6035d33a9aed" />

### Fix Implementation
Change `CMinecraftApp::ActionGameSettings()` and slider implementations to use the method `Minecraft::GetInstance()->options->fov` to adjust FOV.

Change slider range to 0-80 instead of 0-100, change `eGameSetting_FOV` to store FOV as a value 0-80 corresponding to the range 30-110 instead of a value 0-100

Use `SettingFixer()` (from #1097) to seamlessly convert old saved settings to new format.

### AI Use Disclosure
No AI was used to author these changes or pull request.

## Related Issues
- Fixes #655, #666, #771, #838, et al. 
- Related to #1097, #975
