### PR TITLE
Fix: Creative/Survival/Menu Music Issues

### DIFF
--- a/Minecraft.Client/Common/Audio/SoundEngine.cpp
+++ b/Minecraft.Client/Common/Audio/SoundEngine.cpp
@@ -114,7 +114,9 @@ const char *SoundEngine::m_szStreamFileA[eStream_Max]=
 	"hal4",
 	"nuance1",
 	"nuance2",
-
+	"piano1",
+	"piano2",
+	"piano3",
 #ifndef _XBOX
 	"creative1",
 	"creative2",
@@ -127,11 +129,6 @@ const char *SoundEngine::m_szStreamFileA[eStream_Max]=
 	"menu3",
 	"menu4",
 #endif
-
-	"piano1",
-	"piano2",
-	"piano3",
-
 	// Nether
 	"nether1",
 	"nether2",
@@ -191,7 +188,7 @@ void SoundEngine::init(Options* pOptions)
     return;
 }
 
-void SoundEngine::SetStreamingSounds(int iOverworldMin, int iOverWorldMax, int iNetherMin, int iNetherMax, int iEndMin, int iEndMax, int iCD1)
+void SoundEngine::SetStreamingSounds(int iOverworldMin, int iOverWorldMax, int iNetherMin, int iNetherMax, int iEndMin, int iEndMax, int iCD1, int iCreativeMin, int iCreativeMax, int iMenuMin, int iMenuMax)
 {
 	m_iStream_Overworld_Min=iOverworldMin;
 	m_iStream_Overworld_Max=iOverWorldMax;
@@ -199,6 +196,10 @@ void SoundEngine::SetStreamingSounds(int iOverworldMin, int iOverWorldMax, int i
 	m_iStream_Nether_Max=iNetherMax;
 	m_iStream_End_Min=iEndMin;
 	m_iStream_End_Max=iEndMax;
+	m_iStream_Creative_Min=iCreativeMin;
+	m_iStream_Creative_Max=iCreativeMax;
+	m_iStream_Menu_Min=iMenuMin;
+	m_iStream_Menu_Max=iMenuMax;
 	m_iStream_CD_1=iCD1;
 
 	// array to monitor recently played tracks
@@ -407,7 +408,7 @@ SoundEngine::SoundEngine()
 	SetStreamingSounds(eStream_Overworld_Calm1,eStream_Overworld_piano3,
 		eStream_Nether1,eStream_Nether4,
 		eStream_end_dragon,eStream_end_end,
-		eStream_CD_1);
+		eStream_CD_1, eStream_Overworld_Creative1, eStream_Overworld_Creative6, eStream_Overworld_Menu1, eStream_Overworld_Menu4);
 
 	m_musicID=getMusicID(LevelData::DIMENSION_OVERWORLD);
 
@@ -797,7 +798,16 @@ int SoundEngine::getMusicID(int iDomain)
 	if(pMinecraft==nullptr)
 	{
 		// any track from the overworld
-		return GetRandomishTrack(m_iStream_Overworld_Min,m_iStream_Overworld_Max);
+		return GetRandomishTrack(m_iStream_Menu_Min,m_iStream_Menu_Max);
+	}
+
+	int localPlayerIdx = pMinecraft->getLocalPlayerIdx();
+	std::shared_ptr<MultiplayerLocalPlayer> localPlayer = pMinecraft->localplayers[localPlayerIdx];
+
+	if (localPlayer == nullptr)
+	{
+		// any track from the overworld
+		return GetRandomishTrack(m_iStream_Menu_Min,m_iStream_Menu_Max);
 	}
 
 	if(pMinecraft->skins->isUsingDefaultSkin())
@@ -811,7 +821,13 @@ int SoundEngine::getMusicID(int iDomain)
 			return GetRandomishTrack(m_iStream_Nether_Min,m_iStream_Nether_Max);
 			//return m_iStream_Nether_Min + random->nextInt(m_iStream_Nether_Max-m_iStream_Nether_Min);
 		default: //overworld
+			GameType* gt = Player::getPlayerGamePrivilege(localPlayer->getAllPlayerGamePrivileges(), Player::ePlayerGamePrivilege_CreativeMode) ? GameType::CREATIVE : GameType::SURVIVAL;
 			//return m_iStream_Overworld_Min + random->nextInt(m_iStream_Overworld_Max-m_iStream_Overworld_Min);
+
+			if (gt == GameType::CREATIVE)
+			{
+				return GetRandomishTrack(m_iStream_Creative_Min,m_iStream_Creative_Max);
+			}
 			return GetRandomishTrack(m_iStream_Overworld_Min,m_iStream_Overworld_Max);
 		}
 	}
@@ -826,7 +842,7 @@ int SoundEngine::getMusicID(int iDomain)
 			//return m_iStream_Nether_Min + random->nextInt(m_iStream_Nether_Max-m_iStream_Nether_Min);
 			return GetRandomishTrack(m_iStream_Nether_Min,m_iStream_Nether_Max);
 		default: //overworld
-			//return m_iStream_Overworld_Min + random->nextInt(m_iStream_Overworld_Max-m_iStream_Overworld_Min);
+			//Mash-ups don't have special ranges.
 			return GetRandomishTrack(m_iStream_Overworld_Min,m_iStream_Overworld_Max);
 		}
 	}

--- a/Minecraft.Client/Common/Audio/SoundEngine.h
+++ b/Minecraft.Client/Common/Audio/SoundEngine.h
@@ -17,6 +17,10 @@ enum eMUSICFILES
 	eStream_Overworld_hal4,
 	eStream_Overworld_nuance1,
 	eStream_Overworld_nuance2,
+	//Moved these to separate
+	eStream_Overworld_piano1,
+	eStream_Overworld_piano2,
+	eStream_Overworld_piano3, // <-- make piano3 the last overworld one
 #ifndef _XBOX
 	// Add the new music tracks
 	eStream_Overworld_Creative1,
@@ -30,9 +34,7 @@ enum eMUSICFILES
 	eStream_Overworld_Menu3,
 	eStream_Overworld_Menu4,
 #endif
-	eStream_Overworld_piano1,
-	eStream_Overworld_piano2,
-	eStream_Overworld_piano3, // <-- make piano3 the last overworld one
+
 	// Nether
 	eStream_Nether1,
 	eStream_Nether2,
@@ -128,7 +130,7 @@ public:
 	bool isStreamingWavebankReady();		// 4J Added
 	int getMusicID(int iDomain);
 	int getMusicID(const wstring& name);
-	void SetStreamingSounds(int iOverworldMin, int iOverWorldMax, int iNetherMin, int iNetherMax, int iEndMin, int iEndMax, int iCD1);
+	void SetStreamingSounds(int iOverworldMin, int iOverWorldMax, int iNetherMin, int iNetherMax, int iEndMin, int iEndMax, int iCD1, int iCreativeMin, int iCreativeMax, int iMenuMin, int iMenuMax);
 	void updateMiniAudio();
 	void playMusicUpdate();
 
@@ -179,6 +181,8 @@ private:
 	int m_iStream_Nether_Min,m_iStream_Nether_Max;
 	int m_iStream_End_Min,m_iStream_End_Max;
 	int m_iStream_CD_1;
+	int m_iStream_Creative_Min,m_iStream_Creative_Max;
+	int m_iStream_Menu_Min,m_iStream_Menu_Max;
 	bool *m_bHeardTrackA;
 
 #ifdef __ORBIS__

--- a/Minecraft.Client/Common/Consoles_App.cpp
+++ b/Minecraft.Client/Common/Consoles_App.cpp
@@ -3757,7 +3757,7 @@ void CMinecraftApp::HandleXuiActions(void)
 						pMinecraft->soundEngine->SetStreamingSounds(eStream_Overworld_Calm1,eStream_Overworld_piano3,
 							eStream_Nether1,eStream_Nether4,
 							eStream_end_dragon,eStream_end_end,
-							eStream_CD_1);
+							eStream_CD_1, eStream_Overworld_Creative1, eStream_Overworld_Creative6, eStream_Overworld_Menu1, eStream_Overworld_Menu4);
 #endif
 						pMinecraft->soundEngine->playStreaming(L"", 0, 0, 0, 1, 1);
 

--- a/Minecraft.Client/Common/UI/UIController.cpp
+++ b/Minecraft.Client/Common/UI/UIController.cpp
@@ -2067,7 +2067,7 @@ void UIController::NavigateToHomeMenu()
 		pMinecraft->soundEngine->SetStreamingSounds(eStream_Overworld_Calm1,eStream_Overworld_piano3,
 			eStream_Nether1,eStream_Nether4,
 			eStream_end_dragon,eStream_end_end,
-			eStream_CD_1);
+			eStream_CD_1, eStream_Overworld_Creative1, eStream_Overworld_Creative6, eStream_Overworld_Menu1, eStream_Overworld_Menu4);
 		pMinecraft->soundEngine->playStreaming(L"", 0, 0, 0, 1, 1);
 
 		// 		if(pDLCTexPack->m_pStreamedWaveBank!=nullptr)

--- a/Minecraft.Client/DLCTexturePack.cpp
+++ b/Minecraft.Client/DLCTexturePack.cpp
@@ -483,8 +483,9 @@ int DLCTexturePack::packMounted(LPVOID pParam,int iPad,DWORD dwErr,DWORD dwLicen
 					iEndStart=iOverworldC+iNetherC;
 					iEndC=dlcFile->GetCountofType(DLCAudioFile::e_AudioType_End);
 
+					//Mash-up packs don't have these custom ranges.
 					Minecraft::GetInstance()->soundEngine->SetStreamingSounds(iOverworldStart,iOverworldStart+iOverworldC-1,
-						iNetherStart,iNetherStart+iNetherC-1,iEndStart,iEndStart+iEndC-1,iEndStart+iEndC); // push the CD start to after
+						iNetherStart,iNetherStart+iNetherC-1,iEndStart,iEndStart+iEndC-1,iEndStart+iEndC, iOverworldStart,iOverworldStart+iOverworldC-1,iOverworldStart,iOverworldStart+iOverworldC-1); // push the CD start to after
 				}
 #endif
 }


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
<!-- Briefly describe the changes this PR introduces. -->

Separation from previous closed PR #1090 

Separates music properly and prevents music from the wrong gamemode/state playing.
## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->

Sometimes the incorrect songs would play as there was no differentiation of the game's states (eg survival songs might play in the menu, and menu songs might play in creative mode).
### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->

This was because 1. The "piano3" enumerator that the SoundEngine uses came AFTER all of the creative/menu songs, so they were included in the range of songs available to play.
### New Behavior
<!-- Describe how the code behaves after this change. -->

Now the code queries the state of the game and the gamemode of the primary player to determine music properly.
### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->

Added two new [int] ranges for creative and menu music
*, **Updated the SoundEngine::SetStreamingSounds to have arguments for these two ranges
Queried the player's gamemode to differentiate between creative and survival music
All other music defaults to the menu music if no player is present.

*Mash-up packs don't differentiate between these two ranges, so they are identical in the DLCTexturePack.cpp file.
**Defaulted to Creative1-6, Menu1-4.
### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->
No AI was used 🫡 
## Related Issues
- Fixes #1301 
- Related to #1090
