### PR TITLE
Fix: Pose Height/Animation Fixes

### DIFF
--- a/Minecraft.Client/HumanoidModel.cpp
+++ b/Minecraft.Client/HumanoidModel.cpp
@@ -140,6 +140,10 @@ HumanoidModel::HumanoidModel(float g, float yOffset, int texWidth, int texHeight
 	_init(g,yOffset,texWidth,texHeight);
 }
 
+bool HumanoidModel::bitmaskEnabled(unsigned int uiBitmask, animbits bit)
+{
+	return (uiBitmask&(1<<bit))>0;
+}
 void HumanoidModel::render(shared_ptr<Entity> entity, float time, float r, float bob, float yRot, float xRot, float scale, bool usecompiled)
 {	
 	if(entity != nullptr)
@@ -185,6 +189,7 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 	//bool bIsAttacking = (attackTime > -9990.0f);
 	
 	{
+
 		head->yRot = yRot / (float) (180.0f / PI);
 		head->xRot = xRot / (float) (180.0f / PI);
 		hair->yRot = head->yRot;
@@ -193,7 +198,7 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 
 		// Does the skin have an override for anim?
 
-		if(uiBitmaskOverrideAnim&(1<<eAnim_ArmsDown))
+		if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_ArmsDown))
 		{
 			arm0->xRot=0.0f;
 			arm1->xRot=0.0f;
@@ -201,14 +206,14 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 			arm1->zRot = 0.0f;
 
 		}
-		else if(uiBitmaskOverrideAnim&(1<<eAnim_ArmsOutFront))
+		else if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_ArmsOutFront))
 		{
 			arm0->xRot=-HALF_PI;
 			arm1->xRot=-HALF_PI;
 			arm0->zRot = 0.0f;
 			arm1->zRot = 0.0f;
 		}
-		else if(uiBitmaskOverrideAnim&(1<<eAnim_SingleArms))
+		else if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_SingleArms))
 		{
 			arm0->xRot = (Mth::cos(time * 0.6662f + PI) * 2.0f) * r * 0.5f;
 			arm1->xRot = (Mth::cos(time * 0.6662f + PI) * 2.0f) * r * 0.5f;
@@ -216,7 +221,7 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 			arm1->zRot = 0.0f;
 		}
 		// 4J-PB - Weeping Angel - does't look good holding something in the arm that's up
-		else if((uiBitmaskOverrideAnim&(1<<eAnim_StatueOfLiberty)) && (holdingRightHand==0) && (attackTime==0.0f))
+		else if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_StatueOfLiberty) && (holdingRightHand==0) && (attackTime==0.0f))
 		{
 			arm0->xRot = -PI;
 			arm0->zRot = -0.3f;
@@ -241,21 +246,24 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 
 		if (riding)
 		{
-			if(uiBitmaskOverrideAnim&(1<<eAnim_SmallModel) == 0)
+			//Fix this later
+			if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_SmallModel) || bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_SingleLegs))
 			{
+				arm0->xRot += -HALF_PI * 0.4f;
+				arm1->xRot += -HALF_PI * 0.4f;
+				leg0->xRot = -HALF_PI * 0.8f;
+				leg1->xRot = -HALF_PI * 0.8f;
+			}
+			else
+			{
+				//New
 				arm0->xRot += -HALF_PI * 0.4f;
 				arm1->xRot += -HALF_PI * 0.4f;
 				leg0->xRot = -HALF_PI * 0.8f;
 				leg1->xRot = -HALF_PI * 0.8f;
 				leg0->yRot = HALF_PI * 0.2f;
 				leg1->yRot = -HALF_PI * 0.2f;
-			}
-			else
-			{
-				arm0->xRot += -HALF_PI * 0.4f;
-				arm1->xRot += -HALF_PI * 0.4f;
-				leg0->xRot = -HALF_PI * 0.4f;
-				leg1->xRot = -HALF_PI * 0.4f;
+
 			}
 		}
 		else if(idle && !sneaking )
@@ -265,7 +273,7 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 			leg0->yRot = HALF_PI * 0.2f;
 			leg1->yRot = -HALF_PI * 0.2f;
 		}		
-		else if(uiBitmaskOverrideAnim&(1<<eAnim_NoLegAnim))
+		else if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_NoLegAnim))
 		{
 			leg0->xRot=0.0f;
 			leg0->zRot=0.0f;
@@ -274,7 +282,7 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 			leg0->yRot = 0.0f;
 			leg1->yRot = 0.0f;		
 		}
-		else if(uiBitmaskOverrideAnim&(1<<eAnim_SingleLegs))
+		else if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_SingleLegs))
 		{
 			leg0->xRot = ( Mth::cos(time * 0.6662f) * 1.4f) * r;
 			leg1->xRot = ( Mth::cos(time * 0.6662f) * 1.4f) * r;
@@ -318,7 +326,7 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 			arm0->xRot -= aa * 1.2f + bb;	// 4J - changed 1.2 -> 1.2f
 			arm0->yRot += body->yRot * 2.0f;         
 
-			if((uiBitmaskOverrideAnim&(1<<eAnim_StatueOfLiberty))&& (holdingRightHand==0) && (attackTime==0.0f))
+			if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_StatueOfLiberty) && (holdingRightHand==0) && (attackTime==0.0f))
 			{
 				arm0->zRot -= Mth::sin(attackTime * PI) * -0.4f;
 			}
@@ -345,7 +353,7 @@ void HumanoidModel::setupAnim(float time, float r, float bob, float yRot, float 
 
 		if (sneaking)
 		{
-			if(uiBitmaskOverrideAnim&(1<<eAnim_SmallModel))
+			if(bitmaskEnabled(uiBitmaskOverrideAnim, eAnim_SmallModel))
 			{
 				body->xRot = -0.5f;
 				leg0->xRot -= 0.0f;

--- a/Minecraft.Client/HumanoidModel.h
+++ b/Minecraft.Client/HumanoidModel.h
@@ -60,6 +60,7 @@ public:
     void renderEars(float scale, bool usecompiled);
     void renderCloak(float scale, bool usecompiled); 
     void render(HumanoidModel *model, float scale, bool usecompiled);
+	static bool bitmaskEnabled(unsigned int uiBitmask, animbits bit);
 
 // Add new bits to models
 	ModelPart * AddOrRetrievePart(SKIN_BOX *pBox);

--- a/Minecraft.Client/ItemInHandRenderer.cpp
+++ b/Minecraft.Client/ItemInHandRenderer.cpp
@@ -287,6 +287,17 @@ void ItemInHandRenderer::renderItem(shared_ptr<LivingEntity> mob, shared_ptr<Ite
         float xo = 0.0f;
         float yo = 0.3f;
 
+
+		//Re position height of held item if skin is small
+		if (HumanoidModel::bitmaskEnabled(mob->getAnimOverrideBitmask(), HumanoidModel::eAnim_SmallModel)) {
+		if (mob->isRiding()) {
+			std::shared_ptr<Entity> ridingEntity = mob->riding;
+			if (ridingEntity != nullptr) //Safety check;
+			{
+					yo += 0.3f; //reverts the change in Boat.cpp for smaller models.
+			}
+		}
+	}
         glEnable(GL_RESCALE_NORMAL);
         glTranslatef(-xo, -yo, 0);
         float s = 1.5f;

--- a/Minecraft.Client/PlayerRenderer.cpp
+++ b/Minecraft.Client/PlayerRenderer.cpp
@@ -203,7 +203,20 @@ void PlayerRenderer::render(shared_ptr<Entity> _mob, double x, double y, double 
 	{
 		yp -= 2 / 16.0f; //Added more
     }
-	
+	//For some reason the bitmask is zero here
+	unsigned int uiBitmaskOverrideAnim = mob->getSkinAnimOverrideBitmask(mob->getCustomSkin());
+
+	if (HumanoidModel::bitmaskEnabled(uiBitmaskOverrideAnim, HumanoidModel::eAnim_SmallModel)) {
+		if (mob->isRiding()) {
+			std::shared_ptr<Entity> ridingEntity = mob->riding;
+			if (ridingEntity != nullptr) //Safety check;
+			{
+				if (ridingEntity->instanceof(eTYPE_BOAT)) {
+					yp += 0.25f; //reverts the change in Boat.cpp for smaller models.
+				}
+			}
+		}
+	}
 	// Check if an idle animation is needed
 	if(mob->getAnimOverrideBitmask()&(1<<HumanoidModel::eAnim_HasIdle))
 	{
@@ -515,7 +528,7 @@ void PlayerRenderer::renderHand()
     humanoidModel->attackTime = 0;
     humanoidModel->setupAnim(0, 0, 0, 0, 0, 1 / 16.0f, Minecraft::GetInstance()->player);
 	// 4J-PB - does this skin have its arm0 disabled? (Dalek, etc)
-	if((humanoidModel->m_uiAnimOverrideBitmask&(1<<HumanoidModel::eAnim_DisableRenderArm0))==0)
+	if(HumanoidModel::bitmaskEnabled(humanoidModel->m_uiAnimOverrideBitmask, HumanoidModel::eAnim_DisableRenderArm0)==0)
 	{
 		humanoidModel->arm0->render(1 / 16.0f,true);
 	}

--- a/Minecraft.World/Boat.cpp
+++ b/Minecraft.World/Boat.cpp
@@ -26,7 +26,7 @@ void Boat::_init()
 	lxd = lyd = lzd = 0.0;
 
 	blocksBuilding = true;
-	setSize(1.5f, 0.6f);
+	setSize(1.5f, 0.6f); 
 	heightOffset = (bbHeight / 2.0f) + 0.2f;
 
 	// 4J Stu - This function call had to be moved here from the Entity ctor to ensure that
@@ -87,7 +87,7 @@ Boat::Boat(Level *level, double x, double y, double z) : Entity( level )
 
 double Boat::getRideHeight()
 {
-	return heightOffset;
+	return heightOffset - 0.5;
 }
 
 bool Boat::hurt(DamageSource *source, float hurtDamage)


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
<!-- Briefly describe the changes this PR introduces. -->

Fixes the sneak height so the player doesn't float when they sneak. I might merge this with other fixes like boats in the future.

Fixes the boat height / animation for both large and small models.
## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->

Player floated when they crouched.

Player floated on boat, and legs were together.


### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->

Their height in the render script did not go down upon sneak.

Simply did not have the animation code proper.
### New Behavior
<!-- Describe how the code behaves after this change. -->

Added that functionality.

Fixed the improper animation code. Sitting/Riding animations work properly, and small models are positioned correctly.

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/11ec530f-7bec-4340-bc96-6a0745f9cd4b" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/602ee7cc-c4e7-4de4-b767-85d2a61e17cb" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/22f7538b-7b18-4b7d-8220-82e2c1e06736" />

### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->

Replaced "yp" in PlayerRenderer::render, to go down upon sneak. I'm not entirely sure why it blocked sneaking in the first place.

Added a new bitmaskEnabled() function for getBitmaskOverride [localized, cleaned up, readability]
Re-worked boat riding
Added translation for item holding when small models are in a boat.
### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->

## Related Issues
- Fixes #[issue-number]
- Related to #[issue-number]



