### PR TITLE
Fix mouse being pulled to the bottom right

### DIFF
--- a/Minecraft.Client/Common/UI/IUIScene_AbstractContainerMenu.cpp
+++ b/Minecraft.Client/Common/UI/IUIScene_AbstractContainerMenu.cpp
@@ -1298,10 +1298,8 @@ void IUIScene_AbstractContainerMenu::onMouseTick()
 		}
 	}
 
-	vPointerPos.x = floor(vPointerPos.x);
-	vPointerPos.x += ( static_cast<int>(vPointerPos.x)%2);
-	vPointerPos.y = floor(vPointerPos.y);
-	vPointerPos.y += ( static_cast<int>(vPointerPos.y)%2);
+	vPointerPos.x = static_cast<float>(floor(vPointerPos.x + 0.5f));
+	vPointerPos.y = static_cast<float>(floor(vPointerPos.y + 0.5f));
 	m_pointerPos = vPointerPos;
 
 	adjustPointerForSafeZone();


### PR DESCRIPTION
## Description
Fixes a big with imprecisions pushing the mouse position in a certain direction.

## Changes

### Previous Behavior
Previously, mouse movements were pulled slightly to the bottom right. This could be demonstrated by moving the mouse in circles, which caused the cursor to gradually drift to the bottom right instead of staying centered around the same area.

### Root Cause
Pointer snapping logic forced odd coordinates to the next even value (`+ x % 2` or + `y % 2`), which introduced a bias in the positive x/y direction over time.

### New Behavior
Cursor movement is unbiased. Circular mouse motion no longer accumulates drift.

### Fix Implementation
Updated positioning logic in `IUIScene_AbstractContainerMenu::onMouseTick()`:
- Removed biased adjustment
- Replaced with unbiased nearest integer rounding:
    - `vPointerPos.x = floor(vPointerPos.x + 0.5f)`
    - `vPointerPos.y = floor(vPointerPos.y + 0.5f)`

### AI Use Disclosure
No AI was used to solve this issue.

## Related Issues
- Fixes #813 
