### PR TITLE
Added Quick Regen

### DIFF
--- a/Minecraft.World/FoodConstants.cpp
+++ b/Minecraft.World/FoodConstants.cpp
@@ -12,6 +12,7 @@ const float FoodConstants::EXHAUSTION_DROP = 4.0f;
 
 // number of game ticks to change health because of food
 const int FoodConstants::HEALTH_TICK_COUNT = 80;
+const int FoodConstants::QUICK_HEALTH_TICK_COUNT = 10;
 
 const int FoodConstants::HEAL_LEVEL = 18;
 const int FoodConstants::STARVE_LEVEL = 0;

--- a/Minecraft.World/FoodConstants.h
+++ b/Minecraft.World/FoodConstants.h
@@ -13,7 +13,7 @@ public:
 
 	// number of game ticks to change health because of food
 	static const int HEALTH_TICK_COUNT;
-
+	static const int QUICK_HEALTH_TICK_COUNT;
 	static const int HEAL_LEVEL;
 	static const int STARVE_LEVEL;
 

--- a/Minecraft.World/FoodData.cpp
+++ b/Minecraft.World/FoodData.cpp
@@ -65,16 +65,28 @@ void FoodData::tick(shared_ptr<Player> player)
 			}
 		}
 	}
-	else if (player->level->getGameRules()->getBoolean(GameRules::RULE_NATURAL_REGENERATION) && foodLevel >= FoodConstants::HEAL_LEVEL && player->isHurt())
+	else if (player->level->getGameRules()->getBoolean(GameRules::RULE_NATURAL_REGENERATION) && foodLevel >= FoodConstants::MAX_FOOD && player->isHurt())
 	{
 		tickTimer++;
-		if (tickTimer >= FoodConstants::HEALTH_TICK_COUNT)
-		{
-			player->heal(1);
-			addExhaustion(FoodConstants::EXHAUSTION_HEAL);
-			tickTimer = 0;
+
+		if (tickTimer >= FoodConstants::QUICK_HEALTH_TICK_COUNT) {
+			float spent = min(getSaturationLevel(), 6.0f);
+				player->heal(spent / 6.0f);
+				addExhaustion(spent);
+				tickTimer = 0;
 		}
+
+		
 	}
+	else if (player->level->getGameRules()->getBoolean(GameRules::RULE_NATURAL_REGENERATION) && foodLevel >= FoodConstants::HEAL_LEVEL && player->isHurt()) {
+	if (tickTimer >= FoodConstants::HEALTH_TICK_COUNT)
+			{
+				player->heal(1);
+				addExhaustion(FoodConstants::EXHAUSTION_HEAL);
+				tickTimer = 0;
+			}
+	}
+
 	else if (foodLevel <= FoodConstants::STARVE_LEVEL)
 	{
 		tickTimer++;

--- a/Minecraft.World/Player.cpp
+++ b/Minecraft.World/Player.cpp
@@ -1008,11 +1008,6 @@ void Player::aiStep()
 			if ((level->difficulty == Difficulty::PEACEFUL)) {
 				heal(1);
 			}
-			//Quick-Regen from saturation (must have full hunger and have at least 3 saturation)
-			else if (fd->getSaturationLevel() > 3 && fd->getFoodLevel() == 20) {
-				heal(1);
-				fd->setSaturation(fd->getSaturationLevel() - 3);
-			}
 
 		};
 	}

--- a/Minecraft.World/Player.cpp
+++ b/Minecraft.World/Player.cpp
@@ -1004,15 +1004,12 @@ void Player::aiStep()
 	if (level->getGameRules()->getBoolean(GameRules::RULE_NATURAL_REGENERATION)) {
 		bool health_OK = getHealth() < getMaxHealth();
 		if ((tickCount % 12 == 0) && health_OK) {
-
-
-
 			FoodData* fd = getFoodData();
 			if ((level->difficulty == Difficulty::PEACEFUL)) {
 				heal(1);
 			}
-			//Quick-Regen from saturation (must have 8 1/2 hunger and have at least 3 saturation)
-			else if (fd->getSaturationLevel() > 3 && fd->getFoodLevel() >= 17) {
+			//Quick-Regen from saturation (must have full hunger and have at least 3 saturation)
+			else if (fd->getSaturationLevel() > 3 && fd->getFoodLevel() == 20) {
 				heal(1);
 				fd->setSaturation(fd->getSaturationLevel() - 3);
 			}

--- a/Minecraft.World/Player.cpp
+++ b/Minecraft.World/Player.cpp
@@ -1001,9 +1001,23 @@ void Player::aiStep()
 {
 	if (jumpTriggerTime > 0) jumpTriggerTime--;
 
-	if (level->difficulty == Difficulty::PEACEFUL && getHealth() < getMaxHealth() && level->getGameRules()->getBoolean(GameRules::RULE_NATURAL_REGENERATION))
-	{
-		if (tickCount % 20 * 12 == 0) heal(1);
+	if (level->getGameRules()->getBoolean(GameRules::RULE_NATURAL_REGENERATION)) {
+		bool health_OK = getHealth() < getMaxHealth();
+		if ((tickCount % 12 == 0) && health_OK) {
+
+
+
+			FoodData* fd = getFoodData();
+			if ((level->difficulty == Difficulty::PEACEFUL)) {
+				heal(1);
+			}
+			//Quick-Regen from saturation (must have 8 1/2 hunger and have at least 3 saturation)
+			else if (fd->getSaturationLevel() > 3 && fd->getFoodLevel() >= 17) {
+				heal(1);
+				fd->setSaturation(fd->getSaturationLevel() - 3);
+			}
+
+		};
 	}
 	inventory->tick();
 	oBob = bob;


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
<!-- Briefly describe the changes this PR introduces. -->

Added quick regeneration to the player code. A certain level of hunger/saturation are required for quickRegen to be enabled.
## Changes

### Previous Behavior
<!-- Describe how the code behaved before this change. -->

Did not heal according to saturation.
### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->

No code healed the player based on quick regen.
### New Behavior
<!-- Describe how the code behaves after this change. -->

Now quick regen works.
### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->

Added new code in the player::aiStep to query saturation levels and subtract them in each heal. Operates on the same 3 saturation:half heart ratio as in modern LCE.
### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->

## Related Issues
- Fixes #[issue-number]
- Related to #[issue-number]
