### PR TITLE
Increase gain and adjust audio attenuation #897

### DIFF
--- a/Minecraft.Client/Common/Audio/SoundEngine.cpp
+++ b/Minecraft.Client/Common/Audio/SoundEngine.cpp
@@ -260,9 +260,9 @@ void SoundEngine::updateMiniAudio()
             continue;
         }
 
-        float finalVolume = s->info.volume * m_MasterEffectsVolume;
-        if (finalVolume > 1.0f)
-            finalVolume = 1.0f;
+        float finalVolume = s->info.volume * m_MasterEffectsVolume * SFX_VOLUME_MULTIPLIER;
+        if (finalVolume > SFX_MAX_GAIN)
+            finalVolume = SFX_MAX_GAIN;
 
         ma_sound_set_volume(&s->sound, finalVolume);
         ma_sound_set_pitch(&s->sound, s->info.pitch);
@@ -557,10 +557,13 @@ void SoundEngine::play(int iSound, float x, float y, float z, float volume, floa
     }
 
     ma_sound_set_spatialization_enabled(&s->sound, MA_TRUE);
+    ma_sound_set_min_distance(&s->sound, SFX_3D_MIN_DISTANCE);
+    ma_sound_set_max_distance(&s->sound, SFX_3D_MAX_DISTANCE);
+    ma_sound_set_rolloff(&s->sound, SFX_3D_ROLLOFF);
 
-    float finalVolume = volume * m_MasterEffectsVolume;
-    if (finalVolume > 1.0f)
-        finalVolume = 1.0f;
+    float finalVolume = volume * m_MasterEffectsVolume * SFX_VOLUME_MULTIPLIER;
+    if (finalVolume > SFX_MAX_GAIN)
+        finalVolume = SFX_MAX_GAIN;
 
     ma_sound_set_volume(&s->sound, finalVolume);
     ma_sound_set_pitch(&s->sound, pitch);

--- a/Minecraft.Client/Common/Audio/SoundEngine.h
+++ b/Minecraft.Client/Common/Audio/SoundEngine.h
@@ -6,6 +6,12 @@ using namespace std;
 
 #include "miniaudio.h"
 
+constexpr float SFX_3D_MIN_DISTANCE = 1.0f;
+constexpr float SFX_3D_MAX_DISTANCE = 16.0f;
+constexpr float SFX_3D_ROLLOFF = 0.5f;
+constexpr float SFX_VOLUME_MULTIPLIER = 1.5f;
+constexpr float SFX_MAX_GAIN = 1.5f;
+
 enum eMUSICFILES
 {
 	eStream_Overworld_Calm1 = 0,


### PR DESCRIPTION
## Description
Fixed an issue where in-game SFX were quieter than GUI and music,

## Changes

### Previous Behavior
In-game SFX were quieter than GUI sounds and music.

### Root Cause
Sound effects were being attenuated too aggressively due to spatial audio settings and gain limits.

### New Behavior
Sound effects are louder and more consistent with other audio sources while maintaining spatial attenuation.

### Fix Implementation
Adjusted SFX gain scaling and introduced new constants for SFX volume and attenuation. In this case, they are:
- `SFX_3D_MIN_DISTANCE`
- `SFX_3D_MAX_DISTANCE`
- `SFX_3D_ROLLOFF`
- `SFX_VOLUME_MULTIPLIER`
- `SFX_MAX_GAIN`

### AI Use Disclosure
No.

## Related Issues
- Fixes #897 
- And in Discord: [link](https://discord.com/channels/1478227187843858563/1480762326557659166)

https://github.com/user-attachments/assets/ca9f1747-6574-418a-a4a1-f8257c608b21

Video quality isn't the best there, but the main part is the audio.