### PR TITLE
FIX: Item Floating

### DIFF
--- a/Minecraft.World/ItemEntity.cpp
+++ b/Minecraft.World/ItemEntity.cpp
@@ -81,6 +81,9 @@ void ItemEntity::tick()
 	yd -= 0.04f;
 	noPhysics = checkInTile(x, (bb->y0 + bb->y1) / 2, z);
 
+	int tile = level->getTile(x, y, z);
+	if (tile == Tile::calmWater_Id) yd += 0.045f;
+
 	// 4J - added parameter here so that these don't care about colliding with other entities
 	move(xd, yd, zd, true);
 


### PR DESCRIPTION
Items now float in water.

### Description, Previous Behavior, Changes
Item Entities did not float in water. This PR adds an upwards velocity of 0.005f when in water.

### Root Cause
It was not implemented.

### New Behavior
Item Entities now float in water

### Fix Implementation
```
int tile = level->getTile(x, y, z);
if (tile == Tile::calmWater_Id) yd += 0.045f;
```
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/f9f70e2a-f375-4420-8c7a-b7257f3f06cf" />
