### PR TITLE
Switch nightly build archive from zip to 7z (LZMA2)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Build
       run: MSBuild.exe MinecraftConsoles.sln /p:Configuration=Release /p:Platform="Windows64"
 
-    - name: Zip Build
-      run: 7z a -r LCEWindows64.zip ./x64/Release/*
+    - name: Compress Build
+      run: 7z a -r -t7z -m0=lzma2 -mx=7 LCEWindows64.7z ./x64/Release/*
 
     - name: Update release
       uses: andelf/nightly-release@main
@@ -39,8 +39,8 @@ jobs:
           Requires at least Windows 7 and DirectX 11 compatible GPU to run. Compiled with MSVC v14.44.35207 in Release mode with Whole Program Optimization, as well as `/O2 /Ot /Oi /Ob3 /GF /fp:precise`.
           
           # 🚨 First time here? 🚨
-          If you've never downloaded the game before, you need to download `LCEWindows64.zip` and extract it to the folder where you'd like to keep the game. The other files are included in this `.zip` file!
+          If you've never downloaded the game before, you need to download `LCEWindows64.7z` and extract it to the folder where you'd like to keep the game. The other files are included in this `.7z` file!
         files: |
-            LCEWindows64.zip
+            LCEWindows64.7z
             ./x64/Release/Minecraft.Client.exe
             ./x64/Release/Minecraft.Client.pdb


### PR DESCRIPTION
## Description

Switches the nightly build archive from `.zip` to `.7z` (LZMA2). The resulting download is about 14% smaller (732 MB vs 851 MB), which helps people with slow internet since the nightly updates frequently. Windows can extract `.7z` natively now so no extra tools needed.

## Changes

### Previous Behavior

The nightly workflow compressed the release build into a `.zip` file using 7-Zip's default zip mode. Output size was around 851 MB.

### Root Cause

Zip's deflate compression isn't great for this kind of data. 7z with LZMA2 compresses significantly better with no real downside - Windows supports it out of the box and extraction is actually faster.

### New Behavior

The nightly release now uploads `LCEWindows64.7z` instead of `LCEWindows64.zip`. The archive is ~732 MB (down from ~851 MB). The release body text references the new filename.

### Fix Implementation

Changed one line in `.github/workflows/nightly.yml`:

- **Compression command**: `7z a -r -t7z -m0=lzma2 -mx=7 LCEWindows64.7z` instead of `7z a -r LCEWindows64.zip`
- **Release body**: Updated the download instructions to mention `.7z`
- **Files list**: Changed `LCEWindows64.zip` to `LCEWindows64.7z`

Tested by running the workflow manually on a branch - the `.7z` archive was produced correctly and extracts fine.