### PR TITLE
fixed dangling pointer issue

### DIFF
--- a/Minecraft.World/ConsoleSaveFileOutputStream.cpp
+++ b/Minecraft.World/ConsoleSaveFileOutputStream.cpp
@@ -66,7 +66,7 @@ void ConsoleSaveFileOutputStream::write(byteArray b)
 
 	BOOL result = m_saveFile->writeFile(
 		m_file,
-		&b.data, // data buffer
+		b.data, // data buffer
 		b.length, // number of bytes to write
 		&numberOfBytesWritten // number of bytes written
 		);


### PR DESCRIPTION
* fixed dangling pointer issue in ConsoleSaveFileOutputStream::write ( used to pass the address of the pointer rather than a pointer to the buffer itself )