### PR TITLE
Fix audio volume levels for cows and bats

### DIFF
--- a/Minecraft.World/Bat.cpp
+++ b/Minecraft.World/Bat.cpp
@@ -30,7 +30,7 @@ void Bat::defineSynchedData()
 
 float Bat::getSoundVolume()
 {
-	return 0.1f;
+	return 0.8f;
 }
 
 float Bat::getVoicePitch()

--- a/Minecraft.World/Cow.cpp
+++ b/Minecraft.World/Cow.cpp
@@ -72,7 +72,7 @@ void Cow::playStepSound(int xt, int yt, int zt, int t)
 
 float Cow::getSoundVolume() 
 {
-	return 0.4f;
+	return 1.f;
 }
 
 int Cow::getDeathLoot() 


### PR DESCRIPTION
Cow volume 0.4f to 1.f
Bat volume 0.1f to 0.8f

## Description
This PR adjusts the audio volume for Cow and Bat entities to bring them closer to the original Legacy Console Edition (LCE) experience. The previous values were too quiet, making these mobs nearly silent compared to other environmental sounds.

## Changes

### Previous Behavior
Cows had a volume multiplier of 0.4f and Bats were set to 0.1f. This resulted in very faint audio that did not match the punchy, clear soundscape of the original console versions.

### Root Cause
The hardcoded volume values in the entity sound logic were likely placeholders or carry-overs that didn't account for the specific balancing required for LCE parity.

### New Behavior
Cows now have a volume of 1.0f.

Bats now have a volume of 0.8f.
These levels ensure the mobs are audible at a standard distance, consistent with the original console gameplay.

### Fix Implementation
Modified the sound broadcast/play calls for the following entities:

Cow: Updated volume float from 0.4f to 1.0f.

Bat: Updated volume float from 0.1f to 0.8f.

### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->


## Related Issues
- Fixes #1158
- Related to #1158

Before : 
https://github.com/user-attachments/assets/53e3a2bb-5e19-4aa7-8b8f-02e76ccf1896

After :
https://github.com/user-attachments/assets/a9dada6e-16c7-4d2e-b949-7bd995e527a5


