### PR TITLE
Fix: Tooltips Work Properly in Splitscreen

### DIFF
--- a/Minecraft.Client/Common/UI/UIComponent_Tooltips.cpp
+++ b/Minecraft.Client/Common/UI/UIComponent_Tooltips.cpp
@@ -212,8 +212,7 @@ void UIComponent_Tooltips::render(S32 width, S32 height, C4JRender::eViewportTyp
     }
 
 
-	if(m_bSplitscreen)
-	|
+	if(m_bSplitscreen) {
 		//Individiualize the flags for each viewport :)
 		S32 xPos = 0;
 		S32 yPos = 0;


### PR DESCRIPTION
Fixed tooltip changes

<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
<!-- Briefly describe the changes this PR introduces. -->

Fixed the controller tooltips to acknowledge individual pads instead of the primary pad for flagging rendering.


## Changes

Code now has flags set depending on which player is being rendered.
### Previous Behavior
<!-- Describe how the code behaved before this change. -->

Tooltips would only render based on the whether the first player's menu status (they shouldn't even render in the menu like that anyway i dont think)
<img width="1910" height="1079" alt="Screenshot 2026-03-14 142422" src="https://github.com/user-attachments/assets/8a9868e1-ba7b-46f8-abfa-4ba27fbb6e21" />
<img width="1919" height="1079" alt="Screenshot 2026-03-14 142432" src="https://github.com/user-attachments/assets/de73a396-0d01-44e8-8caa-4692e7c670b7" />
<img width="1919" height="1079" alt="Screenshot 2026-03-14 142623" src="https://github.com/user-attachments/assets/dd1952f4-e041-47b1-98b5-4e373a341c11" />

### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->

Return signal before rendering calculations; if the tooltips weren't meant to render for player ONE, they didn't render for any of the players.

### New Behavior
<!-- Describe how the code behaves after this change. -->


Now it queries the settings of each individual pad for whether to render.

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/344a1303-fc83-49d0-b2d9-27122a6e79e3" />

(Player one in this example has tooltips turned off)
### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->

Added two booleans (renderTooltipsOK, menuOKoverride) and one int (plr_pad)
plr_pad is set from a switch statement that gets the pad based on what enumerators were passed into the UI render function.
For example a top-splitscreen player would get pad zero and a bottom-left player would get pad two. I'm not sure if the way I retrieved pads is the most reliable, but it should be a really easy fix if requested.

Anyways that plr_pad is used to query state and settings which flags renderTooltipsOK
an if-return statement is called for renderTooltipsOK so that tooltips are only rendered when necessary

menuOKoverride is initially false, but can be set to true if the level or player does not exist (i.e. the game state is in the main menus)

This way tooltips will render regardless

### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->
i aint no CLANKER
## Related Issues
- Fixes #[issue-number]
- Related to #[issue-number]
