### PR TITLE
Comment out FOV modification line, since the FOV is already stored.

### DIFF
--- a/Minecraft.Client/GameRenderer.cpp
+++ b/Minecraft.Client/GameRenderer.cpp
@@ -392,7 +392,7 @@ float GameRenderer::getFov(float a, bool applyEffects)
 	float fov = m_fov;//70;
 	if (applyEffects)
 	{
-		fov += mc->options->fov * 40;
+		//fov += mc->options->fov * 40;
 		fov *= oFov[playerIdx] + (this->fov[playerIdx] - oFov[playerIdx]) * a;
 	}
 	if (player->getHealth() <= 0)


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
<!-- Briefly describe the changes this PR introduces. -->
I guess this line was just the games way of applying modifications the player made to the FOV. But since whenever ago someone changed the way the FOV stuff is saved, so this line just adds the difference *again* causing issues when the FOV is set above 70. Setting your FOV to 80 actually sets it to 90, and setting it to 110 actually sets it to 150.

Edit: Actually, at least before it became an issue, it doesn't seem to have done anything at all. 

## Changes
Comment out the line that adds the difference.

### Previous Behavior
<!-- Describe how the code behaved before this change. -->
Doubles the change made to the FOV.
[Standing Still] FOV: 110
<img width="1919" height="1079" alt="Before_Still" src="https://github.com/user-attachments/assets/9b44418c-f2aa-4d25-8a79-ef4208399d04" />
[Sprinting] FOV: 110
<img width="1919" height="1079" alt="Before_Spinting" src="https://github.com/user-attachments/assets/c60604ad-38b9-4d6a-8776-f9a71a906f2c" />
[Flying - Sprinting] FOV: 110
<img width="1919" height="1079" alt="Before_Flying" src="https://github.com/user-attachments/assets/26d92d70-a1a2-4e60-8351-090bcf6ac2ed" />


### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->
FOV is now stored, so adding the changed difference causes the FOV to be much higher than intended.

### New Behavior
<!-- Describe how the code behaves after this change. -->
It doesn't do the doubling effect.
[Standing Still] FOV: 110
<img width="1919" height="1079" alt="After_Still" src="https://github.com/user-attachments/assets/656247db-53b2-4375-b19e-80edde9bc02a" />
[Sprinting] FOV: 110
<img width="1919" height="1079" alt="After_Sprinting" src="https://github.com/user-attachments/assets/477ea375-0f65-47ae-bc92-09189fb57df5" />
[Flying - Sprinting] FOV: 110, ignore the potion as it is not being used here.
<img width="1919" height="1079" alt="After_Flying" src="https://github.com/user-attachments/assets/34a3a547-51bc-4afd-84b6-c541c3e6455d" />


### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->
One of the lines inside of FOV effects stuff is commented out. 

### AI Use Disclosure
<!-- Explain, if any, AI was used to solve this problem. Note that we do not accept code written by any LLM in this repo. -->
No AI used here.

## Related Issues
- Related to #1000