### PR TITLE
fix: removed headlesss server logic in favor of the new server exe.

### DIFF
--- a/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
+++ b/Minecraft.Client/Windows64/Windows64_Minecraft.cpp
@@ -121,7 +121,6 @@ static WINDOWPLACEMENT g_wpPrev = { sizeof(g_wpPrev) };
 struct Win64LaunchOptions
 {
 	int screenMode;
-	bool serverMode;
 	bool fullscreen;
 };
 
@@ -207,13 +206,9 @@ static Win64LaunchOptions ParseLaunchOptions()
 {
 	Win64LaunchOptions options = {};
 	options.screenMode = 0;
-	options.serverMode = false;
 
 	g_Win64MultiplayerJoin = false;
 	g_Win64MultiplayerPort = WIN64_NET_DEFAULT_PORT;
-	g_Win64DedicatedServer = false;
-	g_Win64DedicatedServerPort = WIN64_NET_DEFAULT_PORT;
-	g_Win64DedicatedServerBindIP[0] = 0;
 
 	int argc = 0;
 	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
@@ -228,17 +223,6 @@ static Win64LaunchOptions ParseLaunchOptions()
 
 	for (int i = 1; i < argc; ++i)
 	{
-		if (_wcsicmp(argv[i], L"-server") == 0)
-		{
-			options.serverMode = true;
-			break;
-		}
-	}
-
-	g_Win64DedicatedServer = options.serverMode;
-
-	for (int i = 1; i < argc; ++i)
-	{
 		if (_wcsicmp(argv[i], L"-name") == 0 && (i + 1) < argc)
 		{
 			CopyWideArgToAnsi(argv[++i], g_Win64Username, sizeof(g_Win64Username));
@@ -247,15 +231,8 @@ static Win64LaunchOptions ParseLaunchOptions()
 		{
 			char ipBuf[256];
 			CopyWideArgToAnsi(argv[++i], ipBuf, sizeof(ipBuf));
-			if (options.serverMode)
-			{
-				strncpy_s(g_Win64DedicatedServerBindIP, sizeof(g_Win64DedicatedServerBindIP), ipBuf, _TRUNCATE);
-			}
-			else
-			{
-				strncpy_s(g_Win64MultiplayerIP, sizeof(g_Win64MultiplayerIP), ipBuf, _TRUNCATE);
-				g_Win64MultiplayerJoin = true;
-			}
+			strncpy_s(g_Win64MultiplayerIP, sizeof(g_Win64MultiplayerIP), ipBuf, _TRUNCATE);
+			g_Win64MultiplayerJoin = true;
 		}
 		else if (_wcsicmp(argv[i], L"-port") == 0 && (i + 1) < argc)
 		{
@@ -263,10 +240,7 @@ static Win64LaunchOptions ParseLaunchOptions()
 			const long port = wcstol(argv[++i], &endPtr, 10);
 			if (endPtr != argv[i] && *endPtr == 0 && port > 0 && port <= 65535)
 			{
-				if (options.serverMode)
-					g_Win64DedicatedServerPort = static_cast<int>(port);
-				else
-					g_Win64MultiplayerPort = static_cast<int>(port);
+				g_Win64MultiplayerPort = static_cast<int>(port);
 			}
 		}
 		else if (_wcsicmp(argv[i], L"-fullscreen") == 0)
@@ -275,36 +249,6 @@ static Win64LaunchOptions ParseLaunchOptions()
 
 	LocalFree(argv);
 	return options;
-}
-
-static BOOL WINAPI HeadlessServerCtrlHandler(DWORD ctrlType)
-{
-	switch (ctrlType)
-	{
-	case CTRL_C_EVENT:
-	case CTRL_BREAK_EVENT:
-	case CTRL_CLOSE_EVENT:
-	case CTRL_SHUTDOWN_EVENT:
-		app.m_bShutdown = true;
-		MinecraftServer::HaltServer();
-		return TRUE;
-	default:
-		return FALSE;
-	}
-}
-
-static void SetupHeadlessServerConsole()
-{
-	if (AllocConsole())
-	{
-		FILE* stream = nullptr;
-		freopen_s(&stream, "CONIN$", "r", stdin);
-		freopen_s(&stream, "CONOUT$", "w", stdout);
-		freopen_s(&stream, "CONOUT$", "w", stderr);
-		SetConsoleTitleA("Minecraft Server");
-	}
-
-	SetConsoleCtrlHandler(HeadlessServerCtrlHandler, TRUE);
 }
 
 void DefineActions(void)
@@ -1350,161 +1294,6 @@ static Minecraft* InitialiseMinecraftRuntime()
 	return pMinecraft;
 }
 
-static int HeadlessServerConsoleThreadProc(void* lpParameter)
-{
-	UNREFERENCED_PARAMETER(lpParameter);
-
-	std::string line;
-	while (!app.m_bShutdown)
-	{
-		if (!std::getline(std::cin, line))
-		{
-			if (std::cin.eof())
-			{
-				break;
-			}
-
-			std::cin.clear();
-			Sleep(50);
-			continue;
-		}
-
-		wstring command = trimString(convStringToWstring(line));
-		if (command.empty())
-			continue;
-
-		MinecraftServer* server = MinecraftServer::getInstance();
-		if (server != nullptr)
-		{
-			server->handleConsoleInput(command, server);
-		}
-	}
-
-	return 0;
-}
-
-static int RunHeadlessServer()
-{
-	SetupHeadlessServerConsole();
-
-	Settings serverSettings(new File(L"server.properties"));
-	const wstring configuredBindIp = serverSettings.getString(L"server-ip", L"");
-
-	const char* bindIp = "*";
-	if (g_Win64DedicatedServerBindIP[0] != 0)
-	{
-		bindIp = g_Win64DedicatedServerBindIP;
-	}
-	else if (!configuredBindIp.empty())
-	{
-		bindIp = wstringtochararray(configuredBindIp);
-	}
-
-	const int port = g_Win64DedicatedServerPort > 0 ? g_Win64DedicatedServerPort : serverSettings.getInt(L"server-port", WIN64_NET_DEFAULT_PORT);
-
-	printf("Starting headless server on %s:%d\n", bindIp, port);
-	fflush(stdout);
-
-	const Minecraft* pMinecraft = InitialiseMinecraftRuntime();
-	if (pMinecraft == nullptr)
-	{
-		fprintf(stderr, "Failed to initialise the Minecraft runtime.\n");
-		return 1;
-	}
-
-	app.SetGameHostOption(eGameHostOption_Difficulty, serverSettings.getInt(L"difficulty", 1));
-	app.SetGameHostOption(eGameHostOption_Gamertags, 1);
-	app.SetGameHostOption(eGameHostOption_GameType, serverSettings.getInt(L"gamemode", 0));
-	app.SetGameHostOption(eGameHostOption_LevelType, 0);
-	app.SetGameHostOption(eGameHostOption_Structures, serverSettings.getBoolean(L"generate-structures", true) ? 1 : 0);
-	app.SetGameHostOption(eGameHostOption_BonusChest, serverSettings.getBoolean(L"bonus-chest", false) ? 1 : 0);
-	app.SetGameHostOption(eGameHostOption_PvP, serverSettings.getBoolean(L"pvp", true) ? 1 : 0);
-	app.SetGameHostOption(eGameHostOption_TrustPlayers, serverSettings.getBoolean(L"trust-players", true) ? 1 : 0);
-	app.SetGameHostOption(eGameHostOption_FireSpreads, serverSettings.getBoolean(L"fire-spreads", true) ? 1 : 0);
-	app.SetGameHostOption(eGameHostOption_TNT, serverSettings.getBoolean(L"tnt", true) ? 1 : 0);
-	app.SetGameHostOption(eGameHostOption_HostCanFly, 1);
-	app.SetGameHostOption(eGameHostOption_HostCanChangeHunger, 1);
-	app.SetGameHostOption(eGameHostOption_HostCanBeInvisible, 1);
-	app.SetGameHostOption(eGameHostOption_MobGriefing, 1);
-	app.SetGameHostOption(eGameHostOption_KeepInventory, 0);
-	app.SetGameHostOption(eGameHostOption_DoMobSpawning, 1);
-	app.SetGameHostOption(eGameHostOption_DoMobLoot, 1);
-	app.SetGameHostOption(eGameHostOption_DoTileDrops, 1);
-	app.SetGameHostOption(eGameHostOption_NaturalRegeneration, 1);
-	app.SetGameHostOption(eGameHostOption_DoDaylightCycle, 1);
-
-	MinecraftServer::resetFlags();
-	g_NetworkManager.HostGame(0, false, true, MINECRAFT_NET_MAX_PLAYERS, 0);
-
-	if (!WinsockNetLayer::IsActive())
-	{
-		fprintf(stderr, "Failed to bind the server socket on %s:%d.\n", bindIp, port);
-		return 1;
-	}
-
-	g_NetworkManager.FakeLocalPlayerJoined();
-
-	NetworkGameInitData* param = new NetworkGameInitData();
-	param->seed = 0;
-	param->settings = app.GetGameHostOption(eGameHostOption_All);
-
-	g_NetworkManager.ServerStoppedCreate(true);
-	g_NetworkManager.ServerReadyCreate(true);
-
-	C4JThread* thread = new C4JThread(&CGameNetworkManager::ServerThreadProc, param, "Server", 256 * 1024);
-	thread->SetProcessor(CPU_CORE_SERVER);
-	thread->Run();
-
-	g_NetworkManager.ServerReadyWait();
-	g_NetworkManager.ServerReadyDestroy();
-
-	if (MinecraftServer::serverHalted())
-	{
-		fprintf(stderr, "The server halted during startup.\n");
-		g_NetworkManager.LeaveGame(false);
-		return 1;
-	}
-
-	app.SetGameStarted(true);
-	g_NetworkManager.DoWork();
-
-	printf("Server ready on %s:%d\n", bindIp, port);
-	printf("Type 'help' for server commands.\n");
-	fflush(stdout);
-
-	C4JThread* consoleThread = new C4JThread(&HeadlessServerConsoleThreadProc, nullptr, "Server console", 128 * 1024);
-	consoleThread->Run();
-
-	MSG msg = { 0 };
-	while (WM_QUIT != msg.message && !app.m_bShutdown && !MinecraftServer::serverHalted())
-	{
-		if (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-			continue;
-		}
-
-		app.UpdateTime();
-		ProfileManager.Tick();
-		StorageManager.Tick();
-		RenderManager.Tick();
-		ui.tick();
-		g_NetworkManager.DoWork();
-		app.HandleXuiActions();
-
-		Sleep(10);
-	}
-
-	printf("Stopping server...\n");
-	fflush(stdout);
-
-	app.m_bShutdown = true;
-	MinecraftServer::HaltServer();
-	g_NetworkManager.LeaveGame(false);
-	return 0;
-}
-
 int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 					   _In_opt_ HINSTANCE hPrevInstance,
 					   _In_ LPTSTR    lpCmdLine,
@@ -1566,11 +1355,8 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	const Win64LaunchOptions launchOptions = ParseLaunchOptions();
 	ApplyScreenMode(launchOptions.screenMode);
 
-	// Ensure uid.dat exists from startup in client mode (before any multiplayer/login path).
-	if (!launchOptions.serverMode)
-	{
-		Win64Xuid::ResolvePersistentXuid();
-	}
+	// Ensure uid.dat exists from startup (before any multiplayer/login path).
+	Win64Xuid::ResolvePersistentXuid();
 
 	// If no username, let's fall back
 	if (g_Win64Username[0] == 0)
@@ -1651,7 +1437,7 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	MyRegisterClass(hInstance);
 
 	// Perform application initialization:
-	if (!InitInstance (hInstance, launchOptions.serverMode ? SW_HIDE : nCmdShow))
+	if (!InitInstance (hInstance, nCmdShow))
 	{
 		return FALSE;
 	}
@@ -1668,13 +1454,6 @@ int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
 	if (LoadFullscreenOption() && !g_isFullscreen || launchOptions.fullscreen)
 	{
 		ToggleFullscreen();
-	}
-
-	if (launchOptions.serverMode)
-	{
-		const int serverResult = RunHeadlessServer();
-		CleanupDevice();
-		return serverResult;
 	}
 
 #if 0


### PR DESCRIPTION
<!-- 
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

IF YOUR PR CHANGES THE GAME BEHAVIOR VISIBLY, REMEMBER TO ATTACH A GAMEPLAY FOOTAGE (or at least a screenshot) OF YOU *ACTUALLY* PLAYING THE GAME WITH YOUR CHANGES. Untested PRs are *NOT* welcome. Please don't forget to describe what did you do in each commit in your PR.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

We will NOT accept PRs with code authored by AI. If your code
was written by an AI, your PR will be closed. Do not submit
vibe coded PRs.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

PRs that do not fulfill the informational intent of this PR template will be closed. Please do your best to use this template as written.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

-->

## Description
remove the headless server functionality in the client binary (using the old -server flag) in favor of the standalone dedicated server executable.

## Changes
removed [HeadlessServerCtrlHandler], [SetupHeadlessServerConsole], [HeadlessServerConsoleThreadProc], and [RunHeadlessServer] from Windows64_Minecraft.cpp

removed -server flag parsing and [serverMode] field from Win64LaunchOptions

removed dedicated server global initialization ([g_Win64DedicatedServer], [g_Win64DedicatedServerPort], [g_Win64DedicatedServerBindIP]) from client argument parsing

simplified -ip and -port args to only handle client multiplayer join

XUID resolution now runs unconditionally on startup

window is always shown (no more SW_HIDE since -server no longer exists.)


### Previous Behavior
the client executable doubles as a headless server when launched with -server, duplicating functionality that the dedicated server exe now provides.

### Root Cause
The headless server was the original server implementation before minecraft.server was introduced. it's completely unnecessary now that the full dedicated server is implemented.

### New Behavior
The client is client-only. All server functionality is handled by minecraft.server and the exe it compiles.

### Fix Implementation
removed all headless server code paths from Windows64_Minecraft.cpp.
the g_Win64DedicatedServer globals and conditional code in shared files (MinecraftServer.cpp, PlayerList.cpp, WinsockNetLayer.cpp, etc.) are preserved as they're still used when building minecraft.server. 


### AI Use Disclosure
No AI was used for this PR. 
