### PR TITLE
LoadJoinMenu UI Bug Fix: Properly display space indicator, remove label placeholder [BUG: #1004]

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene_LoadOrJoinMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_LoadOrJoinMenu.cpp
@@ -206,6 +206,8 @@ int UIScene_LoadOrJoinMenu::LoadSaveCallback(LPVOID lpParam,bool bRes)
 
 UIScene_LoadOrJoinMenu::UIScene_LoadOrJoinMenu(int iPad, void *initData, UILayer *parentLayer) : UIScene(iPad, parentLayer)
 {
+    constexpr uint64_t MAXIMUM_SAVE_STORAGE = 4LL * 1024LL * 1024LL * 1024LL;
+
     // Setup all the Iggy references we need for this scene
     initialiseMovie();
     app.SetLiveLinkRequired( true );
@@ -230,8 +232,8 @@ UIScene_LoadOrJoinMenu::UIScene_LoadOrJoinMenu(int iPad, void *initData, UILayer
     m_controlJoinTimer.setVisible( true );
 
 
-#if defined(_XBOX_ONE) || defined(__ORBIS__)
-    m_spaceIndicatorSaves.init(L"",eControl_SpaceIndicator,0, (4LL *1024LL * 1024LL * 1024LL) );
+#if defined(_XBOX_ONE) || defined(__ORBIS__) || defined(_WINDOWS64)
+    m_spaceIndicatorSaves.init(L"",eControl_SpaceIndicator,0, MAXIMUM_SAVE_STORAGE);
 #endif
     m_bUpdateSaveSize = false;
 
@@ -695,7 +697,7 @@ void UIScene_LoadOrJoinMenu::tick()
 		if(m_eSaveTransferState == eSaveTransfer_Idle)
 			m_bSaveTransferRunning = false;
 #endif
-#if defined(_XBOX_ONE) || defined(__ORBIS__)
+#if defined(_XBOX_ONE) || defined(__ORBIS__) || defined(_WINDOWS64)
         if(m_bUpdateSaveSize)
         {
             if((m_iDefaultButtonsC > 0) && (m_iSaveListIndex >= m_iDefaultButtonsC))
@@ -716,7 +718,7 @@ void UIScene_LoadOrJoinMenu::tick()
             if(m_pSaveDetails!=nullptr)
             {
                 //CD - Fix - Adding define for ORBIS/XBOXONE
-#if defined(_XBOX_ONE) || defined(__ORBIS__)
+#if defined(_XBOX_ONE) || defined(__ORBIS__) || defined(_WINDOWS64)
                 m_spaceIndicatorSaves.reset();
 #endif
 
@@ -758,6 +760,22 @@ void UIScene_LoadOrJoinMenu::tick()
                 {
 #if defined(_XBOX_ONE)
                     m_spaceIndicatorSaves.addSave(m_pSaveDetails->SaveInfoA[i].totalSize);
+#elif defined(_WINDOWS64)
+                    int origIdx = sortedIdx[i];
+                    wchar_t wFilename[MAX_SAVEFILENAME_LENGTH];
+                    ZeroMemory(wFilename, sizeof(wFilename));
+                    mbstowcs(wFilename, m_pSaveDetails->SaveInfoA[origIdx].UTF8SaveFilename, MAX_SAVEFILENAME_LENGTH - 1);
+                    wstring filePath = wstring(L"Windows64\\GameHDD\\") + wstring(wFilename) + wstring(L"\\saveData.ms");
+
+                    HANDLE hFile = CreateFileW(filePath.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
+                    DWORD fileSize = 0;
+
+                    if (hFile != INVALID_HANDLE_VALUE) {
+                        fileSize = GetFileSize(hFile, nullptr);
+                        if (fileSize < 12 || fileSize == INVALID_FILE_SIZE) fileSize = 0;
+                        CloseHandle(hFile);
+                    }
+                    m_spaceIndicatorSaves.addSave(fileSize);
 #elif defined(__ORBIS__)
                     m_spaceIndicatorSaves.addSave(m_pSaveDetails->SaveInfoA[i].blocksUsed * (32 * 1024) );
 #endif
@@ -770,12 +788,8 @@ void UIScene_LoadOrJoinMenu::tick()
 #else
 #ifdef _WINDOWS64
                     {
-                        int origIdx = sortedIdx[i];
-                        wchar_t wFilename[MAX_SAVEFILENAME_LENGTH];
-                        ZeroMemory(wFilename, sizeof(wFilename));
-                        mbstowcs(wFilename, m_pSaveDetails->SaveInfoA[origIdx].UTF8SaveFilename, MAX_SAVEFILENAME_LENGTH - 1);
-                        wstring filePath = wstring(L"Windows64\\GameHDD\\") + wstring(wFilename) + wstring(L"\\saveData.ms");
                         wstring levelName = ReadLevelNameFromSaveFile(filePath);
+
                         if (!levelName.empty())
                         {
                             m_buttonListSaves.addItem(levelName, wstring(L""));

--- a/Minecraft.Client/Common/UI/UIScene_LoadOrJoinMenu.h
+++ b/Minecraft.Client/Common/UI/UIScene_LoadOrJoinMenu.h
@@ -20,7 +20,7 @@ private:
 	{
 		eControl_SavesList,
 		eControl_GamesList,
-#if defined(_XBOX_ONE) || defined(__ORBIS__)
+#if defined(_XBOX_ONE) || defined(__ORBIS__) || defined(_WINDOWS64)
 		eControl_SpaceIndicator,
 #endif
 	};
@@ -52,7 +52,7 @@ protected:
 	UIControl_SaveList m_buttonListGames;
 	UIControl_Label m_labelSavesListTitle, m_labelJoinListTitle, m_labelNoGames;
 	UIControl m_controlSavesTimer, m_controlJoinTimer;
-#if defined(_XBOX_ONE) || defined(__ORBIS__)
+#if defined(_XBOX_ONE) || defined(__ORBIS__) || defined(_WINDOWS64)
 	UIControl_SpaceIndicatorBar m_spaceIndicatorSaves;
 #endif
 
@@ -68,7 +68,7 @@ private:
 		UI_MAP_ELEMENT( m_controlSavesTimer, "SavesTimer")
 		UI_MAP_ELEMENT( m_controlJoinTimer, "JoinTimer")
 
-#if defined(_XBOX_ONE) || defined(__ORBIS__)
+#if defined(_XBOX_ONE) || defined(__ORBIS__) || defined(_WINDOWS64)
 		UI_MAP_ELEMENT( m_spaceIndicatorSaves, "SaveSizeBar")
 #endif
 	UI_END_MAP_ELEMENTS_AND_NAMES()


### PR DESCRIPTION
## Description
This PR fixes a design flaw that causes the placeholder text (“FJ_Html_LabelBlack”) to appear in the load/join menu UI by restoring the space indicator present on the Xbox One version of the game.

## Changes
### Previous Behavior
The space indicator UI element was not included on the windows version, leading to the game displaying a default placeholder text (“FJ_Html_LabelBlack”).

### Root Cause
This is a Design flaw; developers chose to omit this element, which did not play well with the game’s UI system, leading to placeholder text being present in the load/join menu.

### New Behavior
The element that should be present in the load or join menu now exists, fixing the placeholder text issue, and providing additional information about game save size that was present in the legacy Xbox One version of the game but not in the Windows build.

### Fix Implementation
In the join/load scene, the functionality to create and use the space indicator UI element was set to be included in the Windows build. The method which give this UI element information about the game’s saves was modified to properly retrieve save size on Windows.

### AI Use Disclosure
AI was not used at any point in this pull request.

## Related Issues
- Fixes #1004
- Related to #1037

### Screenshots
Pre-Fix Placeholder Text
<img width="3218" height="1477" alt="prefix" src="https://github.com/user-attachments/assets/0fbf5162-d9e6-4875-b057-145419d1a36d" />
Post-Fix Save Space Indicator: No Save Selected
<img width="3167" height="1461" alt="postfix-nosave" src="https://github.com/user-attachments/assets/70e27aa5-aa4a-4eb9-b1cb-1e809aab654f" />
Post-Fix Save Space Indicator: Save Selected
<img width="3097" height="1377" alt="postfixsave" src="https://github.com/user-attachments/assets/311f9bf9-3eba-4aa4-b3cf-62948bd52faa" />