### PR TITLE
Updated OreFeature to support more than one Tile type

### DIFF
--- a/Minecraft.World/OreFeature.cpp
+++ b/Minecraft.World/OreFeature.cpp
@@ -8,7 +8,7 @@ void OreFeature::_init(int tile, int count, int targetTile, int aux)
 	this->tile = tile;
 	this->count = count;
 	this->targetTile = targetTile;
-	this->aux = aux;
+	this->aux = aux; //default to 0, which is the main block
 }
 
 OreFeature::OreFeature(int tile, int count)
@@ -22,7 +22,7 @@ OreFeature::OreFeature(int tile, int count, int targetTile)
 }
 
 // Nuevo constructor para permitir especificar el valor 'aux'
-OreFeature::OreFeature(int tile, int count, int targetTile, int aux)
+OreFeature::OreFeature(int tile, int count, int targetTile, int aux) //you can use Tile::stone_Id for targetTile
 {
 	_init(tile, count, targetTile, aux);
 }
@@ -141,7 +141,7 @@ bool OreFeature::place(Level *level, Random *random, int x, int y, int z)
 							{
                                 if ( level->getTile(x2, y2, z2) == targetTile)
 								{									
-									level->setTileAndData(x2, y2, z2, tile, this->aux, Tile::UPDATE_INVISIBLE_NO_LIGHT); // Usar this->aux
+									level->setTileAndData(x2, y2, z2, tile, this->aux, Tile::UPDATE_INVISIBLE_NO_LIGHT); // Use this->aux to get the block type
 								}
                             }
                         }

--- a/Minecraft.World/OreFeature.h
+++ b/Minecraft.World/OreFeature.h
@@ -15,7 +15,7 @@ private:
 public:
 	OreFeature (int tile, int count);
 	OreFeature(int tile, int count, int targetTile);
-	OreFeature(int tile, int count, int targetTile, int aux);
+	OreFeature(int tile, int count, int targetTile, int aux); //added to the big constructor to avoid weird interactions as other variables
 
 
 	virtual bool place(Level *level, Random *random, int x, int y, int z);


### PR DESCRIPTION
## Description
This PR adds a new variable inside the constructor from `OreFeature.cpp`(and `OreFeature.h`) called `int aux`.

## Changes
NO new blocks or world gen features are added in this PR. ❗
This small change in the code allows anyone who is modding the game to add different type of the same block in the code.

**For example:**
The Stone Bricks block contains 4 total types (Smooth[the default one], cracked, mossy and chiseled). These type are all the same block, but are differenciated by a number. This `aux` variable allows `OreFeature.cpp` to use those block type, instead of only being able to use the original one.

### Previous Behavior
<!-- Describe how the code behaved before this change. -->
OreFeature could only use the original block type.

### Root Cause
<!-- Explain the core reason behind the erroneous/old behavior (e.g., bug, design flaw, missing edge case). -->
There was no variable to specify the block type.

### New Behavior
<!-- Describe how the code behaves after this change. -->
OreFeature can acces block type and place them correctly in the world!

### Fix Implementation
<!-- Detail exactly how the issue was resolved (specific code changes, algorithms, logic flows). -->
I added `int aux` as an optional variable inside the constructor for OreFeature (when not specified, it defaults to `0`).

The variable is called inside the `setTileAndData` function to `int data`.

### AI Use Disclosure
No AI was used.

## Related Issues
- Fixes #[issue-number]
- Related to #[issue-number]
