### PR TITLE
Fix: The buttons in the some menus do not make a clicking sound

### DIFF
--- a/Minecraft.Client/Common/UI/UIScene_DeathMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_DeathMenu.cpp
@@ -81,6 +81,8 @@ void UIScene_DeathMenu::handleInput(int iPad, int key, bool repeat, bool pressed
 
 void UIScene_DeathMenu::handlePress(F64 controlId, F64 childId)
 {
+	ui.PlayUISFX(eSFX_Press);
+	
 	switch(static_cast<int>(controlId))
 	{
 	case eControl_Respawn:

--- a/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_DebugOverlay.cpp
@@ -183,6 +183,8 @@ void UIScene_DebugOverlay::handleInput(int iPad, int key, bool repeat, bool pres
 
 void UIScene_DebugOverlay::handlePress(F64 controlId, F64 childId)
 {
+	ui.PlayUISFX(eSFX_Press);
+
 	switch(static_cast<int>(controlId))
 	{
 	case eControl_Items:

--- a/Minecraft.Client/Common/UI/UIScene_HelpAndOptionsMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_HelpAndOptionsMenu.cpp
@@ -207,6 +207,8 @@ void UIScene_HelpAndOptionsMenu::handleInput(int iPad, int key, bool repeat, boo
 
 void UIScene_HelpAndOptionsMenu::handlePress(F64 controlId, F64 childId)
 {
+	ui.PlayUISFX(eSFX_Press);
+
 	switch(static_cast<int>(controlId))
 	{
 	case BUTTON_HAO_CHANGESKIN:

--- a/Minecraft.Client/Common/UI/UIScene_PauseMenu.cpp
+++ b/Minecraft.Client/Common/UI/UIScene_PauseMenu.cpp
@@ -504,6 +504,8 @@ void UIScene_PauseMenu::handleInput(int iPad, int key, bool repeat, bool pressed
 
 void UIScene_PauseMenu::handlePress(F64 controlId, F64 childId)
 {
+	ui.PlayUISFX(eSFX_Press);
+	
 	if(m_bIgnoreInput) return;
 
 	switch(static_cast<int>(controlId))


### PR DESCRIPTION
## Description
The buttons in the Help and Options menu, Debug menu, Death menu and Pause menu make a clicking sound after this update.

## Changes

### Previous Behavior
The buttons in the Help and Options menu, Debug menu, Death menu and Pause menu do not play a clicking sound.

### Root Cause
While the `handlePress` function in other menus (such as Settings and Settings Options) have code that plays a click sound, but that code is not in the Help and Options menu, the Debug menu, the Death menu, or the Pause menu 

### New Behavior
The buttons in the Help and Options menu, Debug menu, Death menu and Pause menu play a clicking sound.

### Fix Implementation
I added the line `ui.PlayUISFX(eSFX_Press);` at the beginning of the `handlePress` functions in the menu files (as in `UIScene_SettingsMenu.cpp`, `UIScene_SettingsOptionsMenu.cpp`, etc.).

### AI Use Disclosure
None

## Related Issues
- None
