### PR TITLE
Added Dark Highlight on f3 menu for better visibility

### DIFF
--- a/Minecraft.Client/Gui.cpp
+++ b/Minecraft.Client/Gui.cpp
@@ -1175,13 +1175,13 @@ void Gui::render(float a, bool mouseFree, int xMouse, int yMouse)
         }
 #endif
 
-        int yPos = debugTop;
-        for (const auto &line : lines)
-        {
-            drawString(font, line, debugLeft, yPos, 0xffffff);
-            yPos += 10;
-        }
-
+		int yPos = debugTop;
+		for (const auto& line : lines)
+		{
+			fill(debugLeft - 1, yPos - 1, debugLeft + font->width(line) + 1, yPos + 8 + 1, 0x80303030, true);
+			drawString(font, line, debugLeft, yPos, 0xffffff);
+			yPos += 10;
+		}
         glMatrixMode(GL_MODELVIEW);
         glPopMatrix();
         glMatrixMode(GL_PROJECTION);

--- a/Minecraft.Client/GuiComponent.cpp
+++ b/Minecraft.Client/GuiComponent.cpp
@@ -24,7 +24,7 @@ void GuiComponent::vLine(int x, int y0, int y1, int col)
     fill(x, y0 + 1, x + 1, y1, col);
 }
 
-void GuiComponent::fill(int x0, int y0, int x1, int y1, int col)
+void GuiComponent::fill(int x0, int y0, int x1, int y1, int col, bool blend)
 {
     if (x0 < x1)
 	{
@@ -54,7 +54,9 @@ void GuiComponent::fill(int x0, int y0, int x1, int y1, int col)
     t->vertex(static_cast<float>(x0), static_cast<float>(y0), static_cast<float>(0));
     t->end();
     glEnable(GL_TEXTURE_2D);
-    glDisable(GL_BLEND);
+    if (blend == false) {
+        glDisable(GL_BLEND);
+	}
 }
 
 void GuiComponent::fillGradient(int x0, int y0, int x1, int y1, int col1, int col2)

--- a/Minecraft.Client/GuiComponent.h
+++ b/Minecraft.Client/GuiComponent.h
@@ -9,7 +9,7 @@ protected:
 protected:
 	void hLine(int x0, int x1, int y, int col);
     void vLine(int x, int y0, int y1, int col);
-    void fill(int x0, int y0, int x1, int y1, int col);
+    void fill(int x0, int y0, int x1, int y1, int col, bool blend = false);
     void fillGradient(int x0, int y0, int x1, int y1, int col1, int col2);
 public:
 	GuiComponent();	// 4J added


### PR DESCRIPTION
f3 menu and build text now has dark highlight over text (similar to java) that makes it significantly easier to read text on white background.

## Description
f3 menu and build text now has dark highlight over text (similar to java) that makes it significantly easier to read text on white background.

## Changes

### Previous Behavior
Previously just showed raw text that was hard to read on white background

### Root Cause
Wasn't implemented

### New Behavior
Now has a dark semi-transparent highlight behind the text,

### Fix Implementation
Renders a dark grey box the length and height of the line with half opacity
added an optional "bool blend" argument to the fill function so it can be rendered without the text going fully white. defaults to false (as it was originally)

### Media
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/817193ed-ed72-4cab-bb14-455afeaba5bd" />


### AI Use Disclosure
No Ai.
